### PR TITLE
feature: last known position updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The static info used in `aisreporter` is retrieved from the [Signal K data for s
 
 Optionally the plugin can keep on sending the last known position when position data is not updated, e.g when the GPS device is switched off while docking or for winter break.
 
-![image](https://user-images.githubusercontent.com/1049678/30029804-6207916a-9193-11e7-99d1-fbca6a9c8627.png)
+![image](https://user-images.githubusercontent.com/1049678/121819974-c9f05c00-cc98-11eb-943e-814889a81947.png)
 
 ## Creating Stations
 In order to use this plugin, you will need an IP address and a UDP port number, which requires you to create a station with MarineTraffic, AISHub or another aggregator. In order to create a station, visit [My Stations page on MarineTraffic](https://www.marinetraffic.com/en/users/my_account/stations/index) or [Join Us page on AISHub](https://www.aishub.net/join-us).

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This plugin generates raw NMEA messages using vessel's position, speed, heading,
 
 The static info used in `aisreporter` is retrieved from the [Signal K data for specific paths](https://github.com/SignalK/aisreporter/blob/a14562cd3f3f535f040368f59307bfa6c116ddb1/src/index.ts#L210-L216). The most important values like the MMSI number and the vessel name are available in the server's setting via the UI, for the rest you can use the server's defaults.json mechanism.
 
+Optionally the plugin can keep on sending the last known position when position data is not updated, e.g when the GPS device is switched off while docking or for winter break.
+
 ![image](https://user-images.githubusercontent.com/1049678/30029804-6207916a-9193-11e7-99d1-fbca6a9c8627.png)
 
 ## Creating Stations

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export default function (app: any) {
   let timeout: any
   let lastMessages: [string, string, string] = ['', '', '']
   let lastMsgNmea: any
-  let lastPositonTimeout: any
+  let lastPositionTimeout: any
 
   const plugin: Plugin = {
 
@@ -64,19 +64,18 @@ export default function (app: any) {
             lastMessages[0] = new Date().toISOString() + ':' + msg.nmea
             props.endpoints.forEach((endpoint: Endpoint) => {
               sendReportMsg(msg.nmea, endpoint.ipaddress, endpoint.port)
-
-              lastMsgNmea = msg.nmea
-              if (lastPositonTimeout) {
-                clearInterval(lastPositonTimeout)
-                lastPositonTimeout = undefined
-              }
-              if (props.lastpositonupdate) {
-                lastPositonTimeout = setInterval(
-                  sendLastPositionReport,
-                  (props.lastpositonupdaterate || 180) * 1000
-                )
-              }
             })
+            lastMsgNmea = msg.nmea
+            if (lastPositionTimeout) {
+              clearInterval(lastPositionTimeout)
+              lastPositionTimeout = undefined
+            }
+            if (props.lastpositonupdate) {
+              lastPositionTimeout = setInterval(
+                sendLastPositionReport,
+                (props.lastpositonupdaterate || 180) * 1000
+              )
+            }
           })
 
         var sendLastPositionReport = function () {
@@ -113,9 +112,9 @@ export default function (app: any) {
         clearInterval(timeout)
         timeout = undefined
       }
-      if (lastPositonTimeout) {
-        clearInterval(lastPositonTimeout)
-        lastPositonTimeout = undefined
+      if (lastPositionTimeout) {
+        clearInterval(lastPositionTimeout)
+        lastPositionTimeout = undefined
       }
     },
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export default function (app: any) {
   let timeout: any
   let lastMessages: [string, string, string] = ['', '', '']
   let lastMsgNmea: any
-  let stationary: any
+  let lastPositonTimeout: any
 
   const plugin: Plugin = {
 
@@ -66,21 +66,21 @@ export default function (app: any) {
               sendReportMsg(msg.nmea, endpoint.ipaddress, endpoint.port)
 
               lastMsgNmea = msg.nmea
-              if (stationary) {
-                clearInterval(stationary)
-                stationary = undefined
+              if (lastPositonTimeout) {
+                clearInterval(lastPositonTimeout)
+                lastPositonTimeout = undefined
               }
-              if (props.stationaryupdate) {
-                stationary = setInterval(
-                  sendStationaryReport,
-                  (props.stationaryupdaterate || 180) * 1000
+              if (props.lastpositonupdate) {
+                lastPositonTimeout = setInterval(
+                  sendLastPositionReport,
+                  (props.lastpositonupdaterate || 180) * 1000
                 )
               }
             })
           })
 
-        var sendStationaryReport = function () {
-          lastMessages[0] = 'stationary ' + new Date().toISOString() + ':' + lastMsgNmea
+        var sendLastPositionReport = function () {
+          lastMessages[0] = 'last known ' + new Date().toISOString() + ':' + lastMsgNmea
           props.endpoints.forEach((endpoint: Endpoint) =>  {
               sendReportMsg(lastMsgNmea, endpoint.ipaddress, endpoint.port)
           })
@@ -113,9 +113,9 @@ export default function (app: any) {
         clearInterval(timeout)
         timeout = undefined
       }
-      if (stationary) {
-        clearInterval(stationary)
-        stationary = undefined
+      if (lastPositonTimeout) {
+        clearInterval(lastPositonTimeout)
+        lastPositonTimeout = undefined
       }
     },
 
@@ -160,14 +160,14 @@ export default function (app: any) {
           title: 'Static Update Rate (s)',
           default: 360
         },
-        stationaryupdaterate: {
+        lastpositonupdaterate: {
           type: 'number',
-          title: 'Stationary Update Rate (s)',
+          title: 'Last Known Position Update Rate (s)',
           default: 180
         },
-        stationaryupdate: {
+        lastpositonupdate: {
           type: 'boolean',
-          title: 'Send stationary position updates with last known position when position is not updated',
+          title: 'Keep sending last known position when position data is not updated',
           default: false
         }
       }


### PR DESCRIPTION
Send stationary position updates with last known position when position is not updated from deltas. 

This solves the issue of AIShub account being suspended after not reporting AIS data for 48 hours and being blocked if not sending AIS data for longer times. This happens typically if GPS device (e.g. chart plotter) is switched off while docking or at anchor, or being off even longer for winter break. 

