### PR TITLE
feat: upgrade baconjs from 0.7.x to 3.x and fix for usage in node24

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,14 +20,16 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "baconjs": "^0.7.88",
     "ggencoder": "^0.1.18",
     "lodash": "^4.17.11"
   },
+  "peerDependencies": {
+    "baconjs": "^3.0.0"
+  },
   "devDependencies": {
-    "@types/baconjs": "^0.7.33",
-    "@types/node": "^8.0.0",
+    "baconjs": "^3.0.0",
+    "@types/node": "^18.0.0",
     "prettier-standard": "^8.0.1",
-    "typescript": "^3.0.3"
+    "typescript": "^5.0.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,6 @@
  */
 
 import { combineWith } from 'baconjs'
-import { isUndefined } from 'util'
 import { AisEncode, AisEncodeOptions } from 'ggencoder'
 import * as dgram from 'dgram'
 const _ = require('lodash')
@@ -48,7 +47,7 @@ export default function (app: any) {
 
       try {
         udpSocket = dgram.createSocket('udp4')
-        unsubscribe = combineWith<any, any>(function (position: Position, sog: number, cog: number, head: number) {
+        unsubscribe = (combineWith as any)(function (position: any, sog: number, cog: number, head: number) {
           return createPositionReportMessage(mmsi, position, sog, cog, head)
         }, [
           'navigation.position',
@@ -236,7 +235,7 @@ export default function (app: any) {
 
   function setKey(info: StaticInfo, dest_key: string, source_key: string) {
     const val = app.getSelfPath(source_key)
-    if (!isUndefined(val)) info[dest_key] = val
+    if (val !== undefined) info[dest_key] = val
   }
 
   function getStaticInfo(): StaticInfo {


### PR DESCRIPTION
## Summary

Align with signalk-server which already uses baconjs ^3.0.0.

- Move baconjs from `dependencies` to `peerDependencies`
- Drop `@types/baconjs` — Bacon 3.x ships its own types
- Upgrade `typescript` from 3.x to 5.x and `@types/node` to 18.x (build was broken on master due to ancient TS unable to parse modern `@types/jquery` pulled in transitively by `@types/baconjs`)
- Fix `combineWith` type cast for Bacon 3.x generics
- Replace deprecated `util.isUndefined` with strict comparison (removed in modern Node)

## Manual testing

Tested against a live Signal K server v2.23.0 with a YDWG02 N2K gateway feeding real NMEA 2000 data:

- Plugin loads without "two Bacons loaded" errors
- Static AIS reports (type 24) sent on startup
- Position AIS reports (type 18) sent with live position/SOG/COG from N2K bus
- Verified UDP packets arriving on localhost:12345 via tcpdump
- `tsc` compiles cleanly