### PR TITLE
fix: address issues #6, #27, #32

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,45 @@ interface Position {
   longitude: number
 }
 
+interface CombinedTuple {
+  position: Position | undefined
+  sog: number | undefined
+  cog: number | undefined
+  head: number | undefined
+  nmea: string
+}
+
+// #27: some GPS / chartplotter sources emit (0, 0) as a sentinel when they
+// have no fix (e.g. while powering down). Reporting Null-Island positions
+// to aggregators pollutes their map, so treat a near-zero pair as "no
+// position" rather than a valid reading. Signal K has no explicit
+// validity flag for this.
+function isNullIsland(position: Position | undefined): boolean {
+  if (position === undefined) return false
+  return (
+    Math.abs(position.latitude) < 1e-6 && Math.abs(position.longitude) < 1e-6
+  )
+}
+
+// #6 / #32 — maximum age of the last "dynamic" reading (position update)
+// before static reports stop firing. Twice the default static interval
+// is a pragmatic middle ground: a vessel actively reporting will easily
+// refresh within this, but an idle server without a GPS feed won't keep
+// pinging aggregators with ghost static data.
+const STATIC_MAX_STALE_MS = 10 * 60 * 1000
+
+// #32 — the original plugin persisted these typo'd keys in its schema,
+// and existing SignalK users have them baked into their
+// `plugin-config-data/aisreporter.json`. We publish the corrected keys
+// now, read either spelling (new wins), and — on servers that support
+// app.savePluginOptions — rewrite the config in-place so the user's
+// persisted settings migrate to the corrected spelling without their
+// input.
+const LEGACY_KEYS: Readonly<Record<string, string>> = {
+  lastpositonupdate: 'lastpositionupdate',
+  lastpositonupdaterate: 'lastpositionupdaterate'
+}
+
 const createPlugin = function (app: any) {
   const error =
     app.error ||
@@ -40,6 +79,11 @@ const createPlugin = function (app: any) {
   const lastMessages: [string, string, string] = ['', '', '']
   let lastMsgNmea: string
   let lastPositionTimeout: NodeJS.Timeout | undefined
+  // #6 — tracks the most recent timestamp at which dynamic data arrived.
+  // `undefined` = nothing seen yet, which gates static reports off until
+  // the vessel actually has something to report.
+  let lastDynamicAt: number | undefined
+  let firstDynamicSeen = false
 
   const plugin: Plugin = {
     start: function (props: any) {
@@ -56,6 +100,8 @@ const createPlugin = function (app: any) {
         return
       }
 
+      const cfg = migrateLegacyKeys(props, app, debug)
+
       try {
         udpSocket = dgram.createSocket('udp4')
         // `combineWith` type signature changed between baconjs 1.x and 3.x;
@@ -63,12 +109,19 @@ const createPlugin = function (app: any) {
         // Venus OS still ships baconjs 1.x; upstream signalk-server is on 3.x).
         unsubscribe = (combineWith as any)(
           function (
-            position: Position,
-            sog: number,
-            cog: number,
-            head: number
-          ) {
-            return createPositionReportMessage(mmsi, position, sog, cog, head)
+            position: Position | undefined,
+            sog: number | undefined,
+            cog: number | undefined,
+            head: number | undefined
+          ): CombinedTuple {
+            return {
+              position,
+              sog,
+              cog,
+              head,
+              nmea: createPositionReportMessage(mmsi, position, sog, cog, head)
+                .nmea
+            }
           },
           [
             'navigation.position',
@@ -80,21 +133,41 @@ const createPlugin = function (app: any) {
             .map((s: any) => s.toProperty(undefined))
         )
           .changes()
-          .debounceImmediate((props.updaterate || 60) * 1000)
-          .onValue((msg: any) => {
-            lastMessages[0] = new Date().toISOString() + ':' + msg.nmea
-            props.endpoints.forEach((endpoint: Endpoint) => {
-              sendReportMsg(msg.nmea, endpoint.ipaddress, endpoint.port)
+          .debounceImmediate((cfg.updaterate || 60) * 1000)
+          .onValue((combined: CombinedTuple) => {
+            // #27: drop reports where position is missing or Null-Island.
+            // Aggregators get no frame at all, which is better than a
+            // report parked at 0,0.
+            if (
+              combined.position === undefined ||
+              isNullIsland(combined.position)
+            ) {
+              return
+            }
+            lastMessages[0] = new Date().toISOString() + ':' + combined.nmea
+            cfg.endpoints.forEach((endpoint: Endpoint) => {
+              sendReportMsg(combined.nmea, endpoint.ipaddress, endpoint.port)
             })
-            lastMsgNmea = msg.nmea
+            lastMsgNmea = combined.nmea
+            lastDynamicAt = Date.now()
+
+            // #6: fire a static report the first time we see real
+            // dynamic data so a fresh vessel announces itself to
+            // aggregators immediately. Subsequent static reports fall
+            // to the interval below.
+            if (!firstDynamicSeen) {
+              firstDynamicSeen = true
+              sendStaticReport()
+            }
+
             if (lastPositionTimeout) {
               clearInterval(lastPositionTimeout)
               lastPositionTimeout = undefined
             }
-            if (props.lastpositonupdate) {
+            if (cfg.lastpositionupdate) {
               lastPositionTimeout = setInterval(
                 sendLastPositionReport,
-                (props.lastpositonupdaterate || 180) * 1000
+                (cfg.lastpositionupdaterate || 180) * 1000
               )
             }
           })
@@ -102,23 +175,35 @@ const createPlugin = function (app: any) {
         const sendLastPositionReport = function () {
           lastMessages[0] =
             'last known ' + new Date().toISOString() + ':' + lastMsgNmea
-          props.endpoints.forEach((endpoint: Endpoint) => {
+          cfg.endpoints.forEach((endpoint: Endpoint) => {
             sendReportMsg(lastMsgNmea, endpoint.ipaddress, endpoint.port)
           })
         }
 
         const sendStaticReport = function () {
+          // #6: suppress static reports when no dynamic data has arrived
+          // (or hasn't arrived in a while). Keeps aggregators from
+          // seeing ghost vessels for servers with no GPS feed.
+          if (
+            lastDynamicAt === undefined ||
+            Date.now() - lastDynamicAt > STATIC_MAX_STALE_MS
+          ) {
+            return
+          }
           const info = getStaticInfo()
           if (Object.keys(info).length) {
-            sendStaticPartZero(info, mmsi, props.endpoints)
-            sendStaticPartOne(info, mmsi, props.endpoints)
+            sendStaticPartZero(info, mmsi, cfg.endpoints)
+            sendStaticPartOne(info, mmsi, cfg.endpoints)
           }
         }
 
-        sendStaticReport()
+        // NOTE: no immediate sendStaticReport() here any more (fix for #6).
+        // Startup static is fired from the position handler once we see
+        // the first valid dynamic reading; the interval below carries on
+        // from there.
         timeout = setInterval(
           sendStaticReport,
-          (props.staticupdaterate || 360) * 1000
+          (cfg.staticupdaterate || 360) * 1000
         )
       } catch (e) {
         plugin.started = false
@@ -144,6 +229,10 @@ const createPlugin = function (app: any) {
       if (udpSocket) {
         udpSocket.close()
       }
+      // Reset per-run state so a subsequent start() on the same factory
+      // instance starts from a clean slate.
+      lastDynamicAt = undefined
+      firstDynamicSeen = false
     },
 
     statusMessage: function () {
@@ -187,12 +276,12 @@ const createPlugin = function (app: any) {
           title: 'Static Update Rate (s)',
           default: 360
         },
-        lastpositonupdaterate: {
+        lastpositionupdaterate: {
           type: 'number',
           title: 'Last Known Position Update Rate (s)',
           default: 180
         },
-        lastpositonupdate: {
+        lastpositionupdate: {
           type: 'boolean',
           title:
             'Keep sending last known position when position data is not updated',
@@ -287,6 +376,46 @@ const createPlugin = function (app: any) {
     setKey(info, 'fromCenter', 'sensors.gps.fromCenter.value')
     return info
   }
+}
+
+// #32 — merge legacy typo'd keys into the corrected ones. New key always
+// wins if both are set; legacy keys are kept on the returned object so a
+// failed persistent-migration doesn't break the running start() call.
+// When the server exposes app.savePluginOptions (most versions do), we
+// also persist the migration so the user's on-disk config gets rewritten
+// to the corrected spelling and the legacy form drops away naturally on
+// next restart.
+function migrateLegacyKeys(
+  props: Record<string, unknown>,
+  app: any,
+  debug: (msg: string) => void
+): Record<string, any> {
+  const merged: Record<string, any> = { ...props }
+  let migrated = false
+  for (const [legacy, corrected] of Object.entries(LEGACY_KEYS)) {
+    if (merged[corrected] === undefined && merged[legacy] !== undefined) {
+      merged[corrected] = merged[legacy]
+      migrated = true
+    }
+  }
+  if (migrated && typeof app.savePluginOptions === 'function') {
+    const toPersist = { ...merged }
+    for (const legacy of Object.keys(LEGACY_KEYS)) {
+      delete toPersist[legacy]
+    }
+    app.savePluginOptions(toPersist, (err: Error | undefined) => {
+      if (err) {
+        debug(
+          `aisreporter: legacy-key migration save failed (ignored): ${err.message}`
+        )
+      } else {
+        debug(
+          'aisreporter: migrated legacy config keys (lastpositon* -> lastposition*)'
+        )
+      }
+    })
+  }
+  return merged
 }
 
 interface Endpoint {

--- a/test/plugin.ts
+++ b/test/plugin.ts
@@ -23,6 +23,7 @@ interface Harness {
   app: any
   buses: Record<string, Bacon.Bus<unknown>>
   selfPathValues: Record<string, unknown>
+  savedOptions: Array<Record<string, unknown>>
   received: Buffer[]
   port: number
   close: () => Promise<void>
@@ -46,6 +47,7 @@ async function createHarness(): Promise<Harness> {
 
   const buses: Record<string, Bacon.Bus<unknown>> = {}
   const selfPathValues: Record<string, unknown> = { mmsi: '123456789' }
+  const savedOptions: Array<Record<string, unknown>> = []
 
   const app = {
     streambundle: {
@@ -57,6 +59,15 @@ async function createHarness(): Promise<Harness> {
     getSelfPath(key: string) {
       return selfPathValues[key]
     },
+    // Stub for the server-side config writer used by the #32 migration.
+    // Tests can inspect savedOptions to verify the migration was persisted.
+    savePluginOptions(
+      opts: Record<string, unknown>,
+      cb?: (err?: Error) => void
+    ) {
+      savedOptions.push(opts)
+      if (cb) cb()
+    },
     error: () => undefined,
     debug: () => undefined
   }
@@ -65,6 +76,7 @@ async function createHarness(): Promise<Harness> {
     app,
     buses,
     selfPathValues,
+    savedOptions,
     received,
     port,
     close: () =>
@@ -95,18 +107,16 @@ async function pushPositionInputs(
     cog = 0.5,
     head = 0.7
   }: Partial<{
-    position: { latitude: number; longitude: number }
-    sog: number
-    cog: number
-    head: number
+    position: { latitude: number; longitude: number } | undefined
+    sog: number | undefined
+    cog: number | undefined
+    head: number | undefined
   }> = {},
   debounceWindowMs = 15
 ) {
   h.buses['navigation.speedOverGround']!.push(sog)
   h.buses['navigation.courseOverGroundTrue']!.push(cog)
   h.buses['navigation.headingTrue']!.push(head)
-  // Wait for the leading-edge debounce to settle so the next push opens
-  // a new window and carries all four values through.
   await wait(debounceWindowMs)
   h.buses['navigation.position']!.push(position)
 }
@@ -119,7 +129,7 @@ describe('aisreporter start/stop lifecycle', () => {
       endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
       updaterate: 0.01,
       staticupdaterate: 999,
-      lastpositonupdate: false
+      lastpositionupdate: false
     })
     await pushPositionInputs(h)
     await wait(40)
@@ -127,12 +137,15 @@ describe('aisreporter start/stop lifecycle', () => {
     await h.close()
 
     const payloads = h.received.map((b) => b.toString().trim())
-    // At least one type-18 position report (AIVDM with !AIVDM,1,1,,B,...)
     const posReport = payloads.find((p) => p.startsWith('!AIVDM'))
     expect(posReport, 'expected an AIVDM UDP frame').to.exist
   })
 
-  it('sends both static parts on startup when the app has the full design profile', async () => {
+  // #6 — static reports are now gated on seeing a dynamic reading first.
+  // Every static-test below pushes a position before asserting on the
+  // emitted frames.
+
+  it('sends both static parts on first dynamic when the app has the full design profile', async () => {
     const h = await createHarness()
     h.selfPathValues['name'] = 'Test Vessel'
     h.selfPathValues['design.length.value.overall'] = 12
@@ -145,18 +158,17 @@ describe('aisreporter start/stop lifecycle', () => {
     const plugin = createPlugin(h.app)
     plugin.start({
       endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
-      updaterate: 999,
+      updaterate: 0.01,
       staticupdaterate: 999
     })
-    // The first sendStaticReport call is synchronous; give the UDP a moment.
+    await pushPositionInputs(h)
     await wait(40)
     plugin.stop()
     await h.close()
 
     const payloads = h.received.map((b) => b.toString().trim())
-    // Static reports come as type-24 AIS messages (AIVDM too).
-    // We expect two: part 0 (shipname) + part 1 (dims/callsign).
-    expect(payloads.length).to.be.at.least(2)
+    // Position (type-18) + static part 0 + static part 1 = at least three.
+    expect(payloads.length).to.be.at.least(3)
     expect(payloads.every((p) => p.startsWith('!AIVDM'))).to.equal(true)
   })
 
@@ -166,33 +178,37 @@ describe('aisreporter start/stop lifecycle', () => {
     const plugin = createPlugin(h.app)
     plugin.start({
       endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
-      updaterate: 999,
+      updaterate: 0.01,
       staticupdaterate: 999
     })
+    await pushPositionInputs(h)
     await wait(30)
     plugin.stop()
     await h.close()
     const payloads = h.received.map((b) => b.toString().trim())
-    expect(payloads.length).to.equal(1)
+    // Position + part 0. No part 1 because no shipType / no callsign / no
+    // full dims.
+    expect(payloads.length).to.equal(2)
   })
 
-  it('sends nothing static when neither name, callsign, nor dims are set', async () => {
+  it('sends no static when neither name, callsign, nor dims are set', async () => {
     const h = await createHarness()
     const plugin = createPlugin(h.app)
     plugin.start({
       endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
-      updaterate: 999,
+      updaterate: 0.01,
       staticupdaterate: 999
     })
+    await pushPositionInputs(h)
     await wait(30)
     plugin.stop()
     await h.close()
-    expect(h.received.length).to.equal(0)
+    // Only the position frame — no static content to send.
+    expect(h.received.length).to.equal(1)
   })
 
-  // The remaining static-part-one branches: dims-only and callsign-only.
-  // Together with the shipType-branch test above, every arm of the `||`
-  // gate is exercised.
+  // Cover every arm of the sendStaticPartOne gate:
+  // shipType, dims-only, callsign-only.
 
   it('sends part 1 when only dims (no shipType, no callsign) are set', async () => {
     const h = await createHarness()
@@ -204,13 +220,15 @@ describe('aisreporter start/stop lifecycle', () => {
     const plugin = createPlugin(h.app)
     plugin.start({
       endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
-      updaterate: 999,
+      updaterate: 0.01,
       staticupdaterate: 999
     })
+    await pushPositionInputs(h)
     await wait(30)
     plugin.stop()
     await h.close()
-    expect(h.received.length).to.equal(2)
+    // Position + static part 0 + static part 1.
+    expect(h.received.length).to.equal(3)
   })
 
   it('sends part 1 when only callsign (no shipType, no full dims) is set', async () => {
@@ -220,54 +238,55 @@ describe('aisreporter start/stop lifecycle', () => {
     const plugin = createPlugin(h.app)
     plugin.start({
       endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
-      updaterate: 999,
+      updaterate: 0.01,
       staticupdaterate: 999
     })
+    await pushPositionInputs(h)
     await wait(30)
     plugin.stop()
     await h.close()
-    expect(h.received.length).to.equal(2)
+    // Position + static part 0 + static part 1.
+    expect(h.received.length).to.equal(3)
   })
 
-  it('static rebroadcast fires on staticupdaterate', async () => {
+  it('static rebroadcast fires on staticupdaterate after the first dynamic', async () => {
     const h = await createHarness()
     h.selfPathValues['name'] = 'Repeater'
     const plugin = createPlugin(h.app)
     plugin.start({
       endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
-      updaterate: 999,
-      staticupdaterate: 0.015
+      updaterate: 0.01,
+      staticupdaterate: 0.02
     })
-    await wait(60)
+    await pushPositionInputs(h)
+    await wait(80)
     plugin.stop()
     await h.close()
-    // Initial + at least one rebroadcast ≈ 2+ frames.
-    expect(h.received.length).to.be.at.least(2)
+    // Position + initial static part 0 (fires on first dynamic) + at
+    // least one interval rebroadcast of part 0 = 3+ frames.
+    expect(h.received.length).to.be.at.least(3)
   })
 
-  it('resends last known position on lastpositonupdate interval', async () => {
+  it('resends last known position on lastpositionupdate interval', async () => {
     const h = await createHarness()
     const plugin = createPlugin(h.app)
     plugin.start({
       endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
       updaterate: 0.01,
       staticupdaterate: 999,
-      lastpositonupdate: true,
-      lastpositonupdaterate: 0.015
+      lastpositionupdate: true,
+      lastpositionupdaterate: 0.015
     })
     await pushPositionInputs(h)
     await wait(80)
     plugin.stop()
     await h.close()
-    // Original position + at least one "last known" resend.
     expect(h.received.length).to.be.at.least(2)
   })
 
   it('broadcasts to every configured endpoint', async () => {
     const h1 = await createHarness()
     const h2 = await createHarness()
-    // The second harness borrows the first's app so both receive from the
-    // same plugin instance; only the UDP endpoint list distinguishes them.
     const plugin = createPlugin(h1.app)
     plugin.start({
       endpoints: [
@@ -298,7 +317,6 @@ describe('aisreporter start/stop lifecycle', () => {
     plugin.stop()
     const afterFirstStop = h.received.length
 
-    // Second start(): fresh factory + new streams.
     const h2 = await createHarness()
     const plugin2 = createPlugin(h2.app)
     plugin2.start({
@@ -338,14 +356,6 @@ describe('aisreporter start/stop lifecycle', () => {
 })
 
 describe('aisreporter AIS field encoding', () => {
-  // These tests assert the exact NMEA output bytes against a reference
-  // frame constructed directly with ggencoder. Any drift in the
-  // field-mapping code (mpsToKn, radsToDeg, or the `!== undefined`
-  // guards that decide whether to pass a field through) flips the
-  // encoded bitstream and the comparison fails. This is what gets the
-  // Stryker score up — simple "a frame arrived" assertions pass through
-  // most mutations unnoticed.
-
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { AisEncode } = require('ggencoder')
   const MMSI = '123456789'
@@ -373,7 +383,7 @@ describe('aisreporter AIS field encoding', () => {
       aistype: 18,
       repeat: 0,
       mmsi: MMSI,
-      sog: 1.9438444924574, // 1 m/s converted to knots
+      sog: 1.9438444924574,
       accuracy: 0,
       lon: 20,
       lat: 10,
@@ -388,7 +398,7 @@ describe('aisreporter AIS field encoding', () => {
     ).to.include(expected)
   })
 
-  it('omits sog / cog / hdg / lat / lon when their source value is undefined', async () => {
+  it('still encodes position with sog / cog / hdg unset (only position is required)', async () => {
     const h = await createHarness()
     h.selfPathValues['mmsi'] = MMSI
     const plugin = createPlugin(h.app)
@@ -397,11 +407,10 @@ describe('aisreporter AIS field encoding', () => {
       updaterate: 0.01,
       staticupdaterate: 999
     })
-    h.buses['navigation.position']!.push(undefined)
-    h.buses['navigation.speedOverGround']!.push(undefined)
-    h.buses['navigation.courseOverGroundTrue']!.push(undefined)
-    h.buses['navigation.headingTrue']!.push(undefined)
-    await wait(40)
+    // Push position only — leave sog / cog / head at their .toProperty
+    // seed of undefined. Bypasses pushPositionInputs's numeric defaults.
+    h.buses['navigation.position']!.push({ latitude: 10, longitude: 20 })
+    await wait(30)
     plugin.stop()
     await h.close()
 
@@ -411,13 +420,17 @@ describe('aisreporter AIS field encoding', () => {
       mmsi: MMSI,
       sog: undefined,
       accuracy: 0,
-      lon: undefined,
-      lat: undefined,
+      lon: 20,
+      lat: 10,
       cog: undefined,
       hdg: undefined
     }).nmea
 
-    expect(h.received.map((b) => b.toString().trim())).to.include(expected)
+    const actual = h.received.map((b) => b.toString().trim())
+    expect(
+      actual,
+      `expected a frame equal to ${expected}, got ${JSON.stringify(actual)}`
+    ).to.include(expected)
   })
 
   it('static part 0 encodes shipname bit-for-bit', async () => {
@@ -427,9 +440,10 @@ describe('aisreporter AIS field encoding', () => {
     const plugin = createPlugin(h.app)
     plugin.start({
       endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
-      updaterate: 999,
+      updaterate: 0.01,
       staticupdaterate: 999
     })
+    await pushPositionInputs(h)
     await wait(30)
     plugin.stop()
     await h.close()
@@ -459,15 +473,14 @@ describe('aisreporter AIS field encoding', () => {
     const plugin = createPlugin(h.app)
     plugin.start({
       endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
-      updaterate: 999,
+      updaterate: 0.01,
       staticupdaterate: 999
     })
+    await pushPositionInputs(h)
     await wait(30)
     plugin.stop()
     await h.close()
 
-    // Mirror putDimensions(): dimA = fromBow, dimB = length-fromBow,
-    // dimC = beam/2 + fromCenter, dimD = beam/2 - fromCenter.
     const expected: string = new AisEncode({
       aistype: 24,
       repeat: 0,
@@ -485,8 +498,6 @@ describe('aisreporter AIS field encoding', () => {
   })
 
   it('different positions produce different NMEA frames (sensitivity)', async () => {
-    // Kill mutants like `lat: position !== undefined ? position.latitude : undefined`
-    // → `lat: undefined`: if latitude were dropped, both frames would match.
     async function frameFor(lat: number, lon: number): Promise<string> {
       const h = await createHarness()
       h.selfPathValues['mmsi'] = MMSI
@@ -502,13 +513,243 @@ describe('aisreporter AIS field encoding', () => {
       await wait(30)
       plugin.stop()
       await h.close()
-      // pushPositionInputs emits two frames: a leading-edge [U, sog, cog,
-      // head] and then the full [pos, sog, cog, head]. We want the latter.
       return h.received[h.received.length - 1]!.toString().trim()
     }
     const f1 = await frameFor(10, 20)
     const f2 = await frameFor(-30, 50)
     expect(f1).to.not.equal(f2)
+  })
+})
+
+describe('aisreporter #27 — ignores Null-Island and undefined positions', () => {
+  it('drops reports with position (0, 0) entirely', async () => {
+    const h = await createHarness()
+    const plugin = createPlugin(h.app)
+    plugin.start({
+      endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
+      updaterate: 0.01,
+      staticupdaterate: 999
+    })
+    await pushPositionInputs(h, {
+      position: { latitude: 0, longitude: 0 }
+    })
+    await wait(40)
+    plugin.stop()
+    await h.close()
+    expect(h.received.length).to.equal(0)
+  })
+
+  it('drops reports with near-zero position (GPS noise)', async () => {
+    const h = await createHarness()
+    const plugin = createPlugin(h.app)
+    plugin.start({
+      endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
+      updaterate: 0.01,
+      staticupdaterate: 999
+    })
+    await pushPositionInputs(h, {
+      position: { latitude: 1e-9, longitude: -1e-9 }
+    })
+    await wait(40)
+    plugin.stop()
+    await h.close()
+    expect(h.received.length).to.equal(0)
+  })
+
+  it('drops reports with undefined position', async () => {
+    const h = await createHarness()
+    const plugin = createPlugin(h.app)
+    plugin.start({
+      endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
+      updaterate: 0.01,
+      staticupdaterate: 999
+    })
+    h.buses['navigation.speedOverGround']!.push(1)
+    h.buses['navigation.courseOverGroundTrue']!.push(0.5)
+    h.buses['navigation.headingTrue']!.push(0.7)
+    await wait(15)
+    h.buses['navigation.position']!.push(undefined)
+    await wait(40)
+    plugin.stop()
+    await h.close()
+    expect(h.received.length).to.equal(0)
+  })
+
+  it('still emits reports for valid positions just outside the Null-Island window', async () => {
+    const h = await createHarness()
+    const plugin = createPlugin(h.app)
+    plugin.start({
+      endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
+      updaterate: 0.01,
+      staticupdaterate: 999
+    })
+    await pushPositionInputs(h, {
+      position: { latitude: 0.01, longitude: 0.01 }
+    })
+    await wait(40)
+    plugin.stop()
+    await h.close()
+    expect(h.received.length).to.be.at.least(1)
+  })
+})
+
+describe('aisreporter #6 — gates static on recent dynamic', () => {
+  it('does not send any static report before the first dynamic arrives', async () => {
+    const h = await createHarness()
+    h.selfPathValues['name'] = 'Idle'
+    h.selfPathValues['communication.callsignVhf'] = 'IDLE'
+    const plugin = createPlugin(h.app)
+    plugin.start({
+      endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
+      updaterate: 999,
+      staticupdaterate: 0.01
+    })
+    // Deliberately do NOT push a position. Give the static-interval a
+    // generous window to fire repeatedly and confirm it stays silent.
+    await wait(60)
+    plugin.stop()
+    await h.close()
+    expect(h.received.length).to.equal(0)
+  })
+
+  it('fires static once the first dynamic arrives, then keeps rebroadcasting', async () => {
+    const h = await createHarness()
+    h.selfPathValues['name'] = 'Waking Up'
+    const plugin = createPlugin(h.app)
+    plugin.start({
+      endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
+      updaterate: 0.01,
+      staticupdaterate: 0.02
+    })
+    // Wait through a static-interval cycle with no dynamic → no frames.
+    await wait(30)
+    expect(h.received.length).to.equal(0)
+
+    // Push a position. Expect: position frame + initial static part 0 +
+    // at least one interval rebroadcast.
+    await pushPositionInputs(h)
+    await wait(80)
+    plugin.stop()
+    await h.close()
+    expect(h.received.length).to.be.at.least(3)
+  })
+})
+
+describe('aisreporter #32 — legacy config-key migration', () => {
+  it('reads the legacy lastpositonupdate key when the corrected one is absent', async () => {
+    const h = await createHarness()
+    const plugin = createPlugin(h.app)
+    plugin.start({
+      endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
+      updaterate: 0.01,
+      staticupdaterate: 999,
+      // Old, typo'd key. Expect the plugin to honour it.
+      lastpositonupdate: true,
+      lastpositonupdaterate: 0.015
+    })
+    await pushPositionInputs(h)
+    await wait(80)
+    plugin.stop()
+    await h.close()
+    // Original position + at least one last-known resend.
+    expect(h.received.length).to.be.at.least(2)
+  })
+
+  it('prefers the corrected key when both are set', async () => {
+    // Sanity: if the corrected key disables the resend, no resends fire
+    // even though the legacy key says to enable them.
+    const h = await createHarness()
+    const plugin = createPlugin(h.app)
+    plugin.start({
+      endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
+      updaterate: 0.01,
+      staticupdaterate: 999,
+      lastpositionupdate: false,
+      lastpositonupdate: true,
+      lastpositionupdaterate: 0.015,
+      lastpositonupdaterate: 0.015
+    })
+    await pushPositionInputs(h)
+    await wait(50)
+    plugin.stop()
+    await h.close()
+    // Only the original position — no resend timer because
+    // lastpositionupdate: false wins.
+    expect(h.received.length).to.equal(1)
+  })
+
+  it('persists the migration via app.savePluginOptions when legacy keys are present', async () => {
+    const h = await createHarness()
+    const plugin = createPlugin(h.app)
+    plugin.start({
+      endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
+      updaterate: 999,
+      staticupdaterate: 999,
+      lastpositonupdate: true,
+      lastpositonupdaterate: 180
+    })
+    plugin.stop()
+    await h.close()
+
+    expect(h.savedOptions.length).to.equal(1)
+    const persisted = h.savedOptions[0]!
+    expect(persisted.lastpositionupdate).to.equal(true)
+    expect(persisted.lastpositionupdaterate).to.equal(180)
+    // Legacy keys stripped from the persisted payload.
+    expect(persisted).to.not.have.property('lastpositonupdate')
+    expect(persisted).to.not.have.property('lastpositonupdaterate')
+  })
+
+  it('does not call savePluginOptions when only the corrected keys are present', async () => {
+    const h = await createHarness()
+    const plugin = createPlugin(h.app)
+    plugin.start({
+      endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
+      updaterate: 999,
+      staticupdaterate: 999,
+      lastpositionupdate: true,
+      lastpositionupdaterate: 180
+    })
+    plugin.stop()
+    await h.close()
+    expect(h.savedOptions.length).to.equal(0)
+  })
+
+  it('does not crash when savePluginOptions is absent on older servers', async () => {
+    const h = await createHarness()
+    delete (h.app as any).savePluginOptions
+    const plugin = createPlugin(h.app)
+    expect(() =>
+      plugin.start({
+        endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
+        updaterate: 999,
+        staticupdaterate: 999,
+        lastpositonupdate: true
+      })
+    ).to.not.throw()
+    plugin.stop()
+    await h.close()
+  })
+
+  it('surfaces savePluginOptions callback errors through debug (does not throw)', async () => {
+    const debugMsgs: string[] = []
+    const h = await createHarness()
+    h.app.debug = (m: string) => debugMsgs.push(m)
+    h.app.savePluginOptions = (_opts: unknown, cb?: (err?: Error) => void) => {
+      if (cb) cb(new Error('disk full'))
+    }
+    const plugin = createPlugin(h.app)
+    plugin.start({
+      endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
+      updaterate: 999,
+      staticupdaterate: 999,
+      lastpositonupdate: true
+    })
+    plugin.stop()
+    await h.close()
+    expect(debugMsgs.some((m) => m.includes('migration save failed'))).to.equal(
+      true
+    )
   })
 })
 
@@ -521,7 +762,6 @@ describe('aisreporter initial + schema state', () => {
       updaterate: 999,
       staticupdaterate: 999
     })
-    // No push → no position / static frame → all three slots empty.
     const msg = plugin.statusMessage()
     plugin.stop()
     await h.close()
@@ -530,7 +770,7 @@ describe('aisreporter initial + schema state', () => {
     )
   })
 
-  it('schema declares the UDP-endpoint + rate properties with their documented defaults', () => {
+  it('schema advertises the corrected lastpositionupdate keys', () => {
     const plugin = createPlugin({
       getSelfPath: () => undefined,
       error: () => undefined,
@@ -557,50 +797,43 @@ describe('aisreporter initial + schema state', () => {
       title: 'Static Update Rate (s)',
       default: 360
     })
-    expect(schema.properties.lastpositonupdaterate).to.deep.include({
+    expect(schema.properties.lastpositionupdaterate).to.deep.include({
       type: 'number',
       default: 180
     })
-    expect(schema.properties.lastpositonupdate).to.deep.include({
+    expect(schema.properties.lastpositionupdate).to.deep.include({
       type: 'boolean',
       default: false
     })
+    // Typo'd keys are no longer advertised in the schema; they're still
+    // accepted at runtime via the migration path but the UI should only
+    // show the corrected names.
+    expect(schema.properties).to.not.have.property('lastpositonupdate')
+    expect(schema.properties).to.not.have.property('lastpositonupdaterate')
   })
 })
 
-describe('aisreporter lastpositonupdate timer lifecycle', () => {
+describe('aisreporter lastpositionupdate timer lifecycle', () => {
   it('clears a prior last-position timer when a fresh position arrives', async () => {
-    // Covers the `if (lastPositionTimeout) clearInterval(...)` branch in
-    // the onValue handler: push a first position → last-position timer
-    // starts → push a second position → first timer must be cleared
-    // before a new one is created. If the clear branch mutates to no-op,
-    // both timers run and we'd see roughly double the resends.
     const h = await createHarness()
     const plugin = createPlugin(h.app)
     plugin.start({
       endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
       updaterate: 0.01,
       staticupdaterate: 999,
-      lastpositonupdate: true,
-      lastpositonupdaterate: 0.02
+      lastpositionupdate: true,
+      lastpositionupdaterate: 0.02
     })
     await pushPositionInputs(h, {
       position: { latitude: 10, longitude: 20 }
     })
-    await wait(25)
-    // Reset window to allow a second leading-edge emission with new position.
-    await wait(25)
+    await wait(50)
     await pushPositionInputs(h, {
       position: { latitude: 40, longitude: 50 }
     })
     await wait(60)
     plugin.stop()
     await h.close()
-    // We sent two distinct "real" positions and gave time for multiple
-    // last-known resends. If the clearInterval branch had no-op'd, the
-    // first timer would still be firing alongside the second — i.e. at
-    // least twice as many frames as a single-timer run.
-    // Instead, assert that statusMessage reflects the latest position.
     expect(plugin.statusMessage()).to.include('last known')
   })
 })
@@ -622,16 +855,12 @@ describe('aisreporter plugin falls through its defensive branches', () => {
   })
 
   it('uses console.error / console.log for error + debug when the app omits them', async () => {
-    // The error and debug no-ops are built when app.error / app.debug are
-    // missing. We don't want to actually hit the console during tests, so
-    // patch them while the plugin runs.
     const origErr = console.error
     const origLog = console.log
     console.error = () => undefined
     console.log = () => undefined
     try {
       const h = await createHarness()
-      // Drop app.error and app.debug to exercise the `||` fallbacks.
       delete (h.app as any).error
       delete (h.app as any).debug
       const plugin = createPlugin(h.app)
@@ -656,7 +885,6 @@ describe('aisreporter plugin falls through its defensive branches', () => {
       error: () => undefined,
       debug: () => undefined
     })
-    // No start — unsubscribe, timeout, lastPositionTimeout all undefined.
     expect(() => plugin.stop()).to.not.throw()
   })
 })

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -22,8 +22,8 @@ describe('aisreporter plugin factory', () => {
       'endpoints',
       'updaterate',
       'staticupdaterate',
-      'lastpositonupdaterate',
-      'lastpositonupdate'
+      'lastpositionupdaterate',
+      'lastpositionupdate'
     )
   })
 


### PR DESCRIPTION
Addresses three user-reported issues in one pass. Closes #6, #27, #32.

## #6 — Send static data only if we have dynamic data (tkurki, 2017)

- Track `lastDynamicAt` whenever a valid position arrives.
- `sendStaticReport()` bails when `lastDynamicAt` is `undefined` or older than `STATIC_MAX_STALE_MS` (10 min). A server powered on but without a GPS feed no longer pings aggregators with ghost static.
- First-dynamic trigger: when the very first valid position arrives, fire a static report immediately so new vessels still announce themselves promptly instead of waiting for the next `staticupdaterate` tick.
- Dropped the unconditional `sendStaticReport()` call on `start()`.

## #27 — Ignore wrong positions (Null Island) (akileos, 2022)

- `isNullIsland(pos)` returns true when `|lat| < 1e-6 && |lon| < 1e-6`.
  Some GPS / chartplotter sources emit `(0, 0)` as a sentinel when they have no fix, and Signal K has no explicit validity flag.
- The `combineWith` `onValue` handler drops frames whose position is `undefined` or near-zero so aggregators don't see the vessel parked at 0,0.

## #32 — Position spelled as positon in code (keesverruijt, 2025)

**Migration strategy: dual-read + opportunistic persist** — zero breakage for existing users.

- Schema advertises `lastpositionupdate` / `lastpositionupdaterate` (corrected) instead of the typo'd keys.
- `migrateLegacyKeys()` reads `lastpositonupdate` as a fallback when the corrected key is absent, so existing users' persisted config keeps working. New key wins if both are present.
- When the server exposes `app.savePluginOptions` (most versions do), the migration persists the corrected spelling to disk so the legacy form drops away naturally on next restart — users never have to touch their config.
- Dropped the typo'd keys from the schema; they're still honoured at runtime but the UI only shows the new names.

## Tests

| | Before | After |
|---|---|---|
| passing | 26 | **38** |
| lines | 96.66 % | **97.52 %** |
| functions | 100 % | 100 % |
| mutation score | 91.47 % | 86.93 % |

The mutation score dropped because the new code introduced surface area faster than the new tests killed it (32 survivors mostly in the `STATIC_MAX_STALE_MS` threshold-age checks and `undefined`-guard redundancies that can't be exercised without fake timers).

New test coverage for each issue:

- **#27** — Null-Island filter, near-zero noise filter, undefined-position filter, valid-position-just-outside-the-window passes through.
- **#6** — static stays silent before first dynamic, fires on first dynamic, keeps rebroadcasting while dynamic is fresh.
- **#32** — legacy key read, corrected key wins over legacy, persistent migration via `app.savePluginOptions`, server-without-savePluginOptions path, `savePluginOptions` callback error path.

## Test plan

- [x] `npm run prettier:check` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] `npm test` 38 / 38 passing
- [x] `npm run coverage` 97.52 % lines
- [x] `npm run mutation` 86.93 %
- [x] CI green on Node 22 + 24 × baconjs 1.0.1 + 3.0.23

Closes #6, #27, #32.