### PR TITLE
refactor: use @signalk/server-api types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "ggencoder": "^1.0.9"
       },
       "devDependencies": {
+        "@signalk/server-api": "^2.24.0",
         "@stryker-mutator/core": "^9.6.1",
         "@stryker-mutator/mocha-runner": "^9.6.1",
         "@types/chai": "^5.2.3",
@@ -1438,6 +1439,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@js-temporal/polyfill": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.5.1.tgz",
+      "integrity": "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "jsbi": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1453,6 +1467,25 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@signalk/server-api": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/@signalk/server-api/-/server-api-2.24.0.tgz",
+      "integrity": "sha512-IZWVIuV/vOG4obKZ7vhUCfZ19XhpmXlUq8MNV9G10S6vF2vBKZ6JiOaYVVAyzbihlzPafD4Mq7wGurvWur1a0g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@js-temporal/polyfill": "^0.5.1",
+        "@sinclair/typebox": "^0.34.0",
+        "baconjs": "^3.0.0"
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
       "dev": true,
       "license": "MIT"
     },
@@ -2829,6 +2862,13 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsbi": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.2.tgz",
+      "integrity": "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/jsesc": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "baconjs": "^3.0.0"
   },
   "devDependencies": {
+    "@signalk/server-api": "^2.24.0",
     "@stryker-mutator/core": "^9.6.1",
     "@stryker-mutator/mocha-runner": "^9.6.1",
     "@types/chai": "^5.2.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,11 +16,7 @@
 import { combineWith } from 'baconjs'
 import { AisEncode } from 'ggencoder'
 import * as dgram from 'dgram'
-
-interface Position {
-  latitude: number
-  longitude: number
-}
+import type { Path, Plugin, Position, ServerAPI } from '@signalk/server-api'
 
 interface CombinedTuple {
   position: Position | undefined
@@ -56,7 +52,7 @@ const LEGACY_KEYS: Readonly<Record<string, string>> = {
   lastpositonupdaterate: 'lastpositionupdaterate'
 }
 
-const createPlugin = function (app: any) {
+const createPlugin = function (app: ServerAPI) {
   const error =
     app.error ||
     ((msg: string) => {
@@ -77,7 +73,7 @@ const createPlugin = function (app: any) {
   let lastDynamicAt: number | undefined
   let firstDynamicSeen = false
 
-  const plugin: Plugin = {
+  const plugin: Plugin & { started: boolean } = {
     start: function (props: any) {
       if (!app.getSelfPath) {
         error(
@@ -85,7 +81,7 @@ const createPlugin = function (app: any) {
         )
         return
       }
-      const mmsi: string = app.getSelfPath('mmsi')
+      const mmsi = app.getSelfPath('mmsi') as string | undefined
 
       if (!mmsi) {
         error('aisreporter: mmsi missing in settings')
@@ -115,12 +111,14 @@ const createPlugin = function (app: any) {
                 .nmea
             }
           },
-          [
-            'navigation.position',
-            'navigation.speedOverGround',
-            'navigation.courseOverGroundTrue',
-            'navigation.headingTrue'
-          ]
+          (
+            [
+              'navigation.position',
+              'navigation.speedOverGround',
+              'navigation.courseOverGroundTrue',
+              'navigation.headingTrue'
+            ] as Path[]
+          )
             .map(app.streambundle.getSelfStream, app.streambundle)
             .map((s: any) => s.toProperty(undefined))
         )
@@ -369,7 +367,7 @@ const createPlugin = function (app: any) {
 // on-disk config so the legacy form drops away on next restart.
 function migrateLegacyKeys(
   props: Record<string, unknown>,
-  app: any,
+  app: ServerAPI,
   debug: (msg: string) => void
 ): Record<string, any> {
   const merged: Record<string, any> = { ...props }
@@ -388,7 +386,7 @@ function migrateLegacyKeys(
     for (const legacy of Object.keys(LEGACY_KEYS)) {
       delete toPersist[legacy]
     }
-    app.savePluginOptions(toPersist, (err: Error | undefined) => {
+    app.savePluginOptions(toPersist, (err) => {
       if (err) {
         debug(
           `aisreporter: legacy-key migration save failed (ignored): ${err.message}`
@@ -417,17 +415,6 @@ interface StaticInfo {
   fromBow?: number
   fromCenter?: number
   [key: string]: unknown
-}
-
-interface Plugin {
-  start: (app: any) => void
-  started: boolean
-  stop: () => void
-  statusMessage: (msg?: string) => string
-  id: string
-  name: string
-  description: string
-  schema: any
 }
 
 function createPositionReportMessage(


### PR DESCRIPTION
## Summary

Replace the local `Plugin` and `Position` interfaces and the `app: any` parameter with `Plugin`, `Position`, `Path`, and `ServerAPI` imported from `@signalk/server-api`.

The local types were a partial restatement of types already exported by the server-api package. Using the canonical types removes the duplication and means future additions to the server API are picked up automatically.

`@signalk/server-api` is added as a `devDependency` (types-only consumption; runtime instances come from the host server).

`started: boolean` is kept as a local intersection on the plugin object since it is not part of the server-api `Plugin` contract.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `npm test` passes (45 tests)
- [x] `npm run prettier:check` passes