### PR TITLE
fix: drop baconjs to resolve silent stream stall on Venus OS (#46)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
         "@types/node": "^22.10.5",
-        "baconjs": "^3.0.0",
         "c8": "^11.0.0",
         "chai": "^6.2.2",
         "mocha": "^11.7.5",
@@ -28,10 +27,8 @@
         "typescript": "^6.0.3"
       },
       "engines": {
-        "node": ">=22"
-      },
-      "peerDependencies": {
-        "baconjs": "^3.0.0"
+        "//": "Floor at 20.10 to support Venus CerboGX firmware (currently Node 20.18.2). Bump back to >=22 once Cerbo ships a newer Node.",
+        "node": ">=20.10"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -62,9 +62,6 @@
   "dependencies": {
     "ggencoder": "^1.0.9"
   },
-  "peerDependencies": {
-    "baconjs": "^3.0.0"
-  },
   "devDependencies": {
     "@signalk/server-api": "^2.24.0",
     "@stryker-mutator/core": "^9.6.1",
@@ -72,7 +69,6 @@
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
     "@types/node": "^22.10.5",
-    "baconjs": "^3.0.0",
     "c8": "^11.0.0",
     "chai": "^6.2.2",
     "mocha": "^11.7.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,27 +13,21 @@
  * limitations under the License.
  */
 
-import { combineWith } from 'baconjs'
 import { AisEncode } from 'ggencoder'
 import * as dgram from 'dgram'
-import type { Path, Plugin, Position, ServerAPI } from '@signalk/server-api'
-
-interface CombinedTuple {
-  position: Position | undefined
-  sog: number | undefined
-  cog: number | undefined
-  head: number | undefined
-  nmea: string
-}
+import type { Plugin, Position, ServerAPI } from '@signalk/server-api'
 
 // Some GPS / chartplotter sources emit (0, 0) as a sentinel when they
 // have no fix (e.g. while powering down), and Signal K has no explicit
 // validity flag. Treat a near-zero pair as "no position" so aggregators
-// don't see the vessel parked at Null Island.
-function isNullIsland(position: Position | undefined): boolean {
-  if (position === undefined) return false
+// don't see the vessel parked at Null Island. 1e-6 degrees is ~11 cm
+// at the equator — anything below that is GPS-noise around zero, not a
+// real fix.
+const NULL_ISLAND_EPSILON_DEG = 1e-6
+function isNullIsland(position: Position): boolean {
   return (
-    Math.abs(position.latitude) < 1e-6 && Math.abs(position.longitude) < 1e-6
+    Math.abs(position.latitude) < NULL_ISLAND_EPSILON_DEG &&
+    Math.abs(position.longitude) < NULL_ISLAND_EPSILON_DEG
   )
 }
 
@@ -52,6 +46,61 @@ const LEGACY_KEYS: Readonly<Record<string, string>> = {
   lastpositonupdaterate: 'lastpositionupdaterate'
 }
 
+// Keep operator-typo configs (NaN, negatives, strings) from arming a
+// pathologically tight setInterval that hammers aggregators. A 0 from
+// the schema is treated as "use default" rather than "send constantly".
+function sanitizeRateSeconds(value: unknown, defaultSeconds: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return defaultSeconds
+  }
+  return value
+}
+
+// Drop endpoints whose ipaddress or port can't be safely passed to
+// dgram.send. The schema only types these loosely (string + number); a
+// hand-edited config file or future schema relaxation could let through
+// objects, empty strings, fractional ports, or values containing
+// CR/LF that would smear the log lines we emit alongside each send.
+function sanitizeEndpoints(
+  endpoints: unknown,
+  warn: (msg: string) => void
+): Endpoint[] {
+  if (!Array.isArray(endpoints)) return []
+  const result: Endpoint[] = []
+  for (const ep of endpoints) {
+    if (!ep || typeof ep !== 'object') {
+      warn(
+        `aisreporter: ignoring endpoint, not an object: ${JSON.stringify(ep)}`
+      )
+      continue
+    }
+    const candidate = ep as { ipaddress?: unknown; port?: unknown }
+    if (
+      typeof candidate.ipaddress !== 'string' ||
+      candidate.ipaddress.length === 0 ||
+      /[\r\n]/.test(candidate.ipaddress)
+    ) {
+      warn(
+        `aisreporter: ignoring endpoint with invalid ipaddress: ${JSON.stringify(candidate.ipaddress)}`
+      )
+      continue
+    }
+    if (
+      typeof candidate.port !== 'number' ||
+      !Number.isInteger(candidate.port) ||
+      candidate.port < 1 ||
+      candidate.port > 65535
+    ) {
+      warn(
+        `aisreporter: ignoring endpoint with invalid port: ${JSON.stringify(candidate.port)}`
+      )
+      continue
+    }
+    result.push({ ipaddress: candidate.ipaddress, port: candidate.port })
+  }
+  return result
+}
+
 const createPlugin = function (app: ServerAPI) {
   const error =
     app.error ||
@@ -64,149 +113,170 @@ const createPlugin = function (app: ServerAPI) {
       console.log(msg)
     })
 
-  let udpSocket: dgram.Socket
-  let unsubscribe: () => void
-  let timeout: NodeJS.Timeout | undefined
+  let udpSocket: dgram.Socket | undefined
+  let dynamicTimer: NodeJS.Timeout | undefined
+  let staticTimer: NodeJS.Timeout | undefined
+  let lastPositionTimer: NodeJS.Timeout | undefined
   const lastMessages: [string, string, string] = ['', '', '']
   let lastMsgNmea: string
-  let lastPositionTimeout: NodeJS.Timeout | undefined
   let lastDynamicAt: number | undefined
   let firstDynamicSeen = false
+  // Surfaces a misconfigured/disabled state through statusMessage() so
+  // the SignalK admin UI doesn't silently show "Last sent messages: ..."
+  // with empty slots while the plugin is in fact disabled because of a
+  // missing mmsi or an outdated server.
+  let lastStartError: string | undefined
 
   const plugin: Plugin & { started: boolean } = {
     start: function (props: any) {
+      lastStartError = undefined
       if (!app.getSelfPath) {
-        error(
-          'Please upgrade the server, aisreporter needs app.getSelfPath and will not start'
-        )
+        const msg =
+          'aisreporter not started: server too old (no app.getSelfPath)'
+        error(msg)
+        lastStartError = msg
+        plugin.started = false
         return
       }
       const mmsi = app.getSelfPath('mmsi') as string | undefined
 
       if (!mmsi) {
-        error('aisreporter: mmsi missing in settings')
+        const msg = 'aisreporter not started: mmsi missing in settings'
+        error(msg)
+        lastStartError = msg
+        plugin.started = false
         return
       }
 
       const cfg = migrateLegacyKeys(props, app, debug)
+      cfg.endpoints = sanitizeEndpoints(cfg.endpoints, error)
+      const updateRateSec = sanitizeRateSeconds(cfg.updaterate, 60)
+      const staticRateSec = sanitizeRateSeconds(cfg.staticupdaterate, 360)
+      const lastPositionRateSec = sanitizeRateSeconds(
+        cfg.lastpositionupdaterate,
+        180
+      )
 
-      try {
-        udpSocket = dgram.createSocket('udp4')
-        // `combineWith` type signature changed between baconjs 1.x and 3.x;
-        // the cast keeps us compatible across the dual-version matrix (Cerbo
-        // Venus OS still ships baconjs 1.x; upstream signalk-server is on 3.x).
-        unsubscribe = (combineWith as any)(
-          function (
-            position: Position | undefined,
-            sog: number | undefined,
-            cog: number | undefined,
-            head: number | undefined
-          ): CombinedTuple {
-            return {
-              position,
-              sog,
-              cog,
-              head,
-              nmea: createPositionReportMessage(mmsi, position, sog, cog, head)
-                .nmea
-            }
-          },
-          (
-            [
-              'navigation.position',
-              'navigation.speedOverGround',
-              'navigation.courseOverGroundTrue',
-              'navigation.headingTrue'
-            ] as Path[]
+      udpSocket = dgram.createSocket('udp4')
+      // Poll vessel state through the public ServerAPI rather than
+      // subscribing to streambundle Bacon streams. The stream-based
+      // path silently stalls on hosts that ship a different baconjs
+      // version than the plugin's transitive copy: combine-pipelines
+      // wire up without error but never emit. Polling sidesteps the
+      // dual-Bacon problem entirely and matches the plugin's actual
+      // semantics, which are timer-driven (one report per updaterate).
+      let lastEmittedLat: number | undefined
+      let lastEmittedLon: number | undefined
+      const tick = () => {
+        const position = app.getSelfPath('navigation.position.value') as
+          | Position
+          | undefined
+        if (position === undefined || isNullIsland(position)) return
+        // Skip when lat/lon haven't moved since the previous emission.
+        // Without this, a host whose tree is updated by deltas of the
+        // same value (anchored vessel, stuck GPS) would keep firing
+        // identical AIS frames at aggregators every tick.
+        if (
+          position.latitude === lastEmittedLat &&
+          position.longitude === lastEmittedLon
+        ) {
+          return
+        }
+        const sog = app.getSelfPath('navigation.speedOverGround.value') as
+          | number
+          | undefined
+        const cog = app.getSelfPath('navigation.courseOverGroundTrue.value') as
+          | number
+          | undefined
+        const head = app.getSelfPath('navigation.headingTrue.value') as
+          | number
+          | undefined
+
+        const nmea = createPositionReportMessage(
+          mmsi,
+          position,
+          sog,
+          cog,
+          head
+        ).nmea
+        lastMessages[0] = new Date().toISOString() + ':' + nmea
+        cfg.endpoints.forEach((endpoint: Endpoint) => {
+          sendReportMsg(nmea, endpoint.ipaddress, endpoint.port)
+        })
+        lastMsgNmea = nmea
+        lastDynamicAt = Date.now()
+        lastEmittedLat = position.latitude
+        lastEmittedLon = position.longitude
+
+        // Announce a fresh vessel to aggregators immediately on its
+        // first real dynamic reading; subsequent static reports fall
+        // to the interval below.
+        if (!firstDynamicSeen) {
+          firstDynamicSeen = true
+          sendStaticReport()
+        }
+
+        // Reset the staleness clock on every fresh dynamic — the
+        // last-known-position interval represents "time since last
+        // real position", not a fixed cadence, so it must restart
+        // whenever a new position arrives.
+        if (lastPositionTimer) {
+          clearInterval(lastPositionTimer)
+          lastPositionTimer = undefined
+        }
+        if (cfg.lastpositionupdate) {
+          lastPositionTimer = setInterval(
+            sendLastPositionReport,
+            lastPositionRateSec * 1000
           )
-            .map(app.streambundle.getSelfStream, app.streambundle)
-            .map((s: any) => s.toProperty(undefined))
-        )
-          .changes()
-          .debounceImmediate((cfg.updaterate || 60) * 1000)
-          .onValue((combined: CombinedTuple) => {
-            if (
-              combined.position === undefined ||
-              isNullIsland(combined.position)
-            ) {
-              return
-            }
-            lastMessages[0] = new Date().toISOString() + ':' + combined.nmea
-            cfg.endpoints.forEach((endpoint: Endpoint) => {
-              sendReportMsg(combined.nmea, endpoint.ipaddress, endpoint.port)
-            })
-            lastMsgNmea = combined.nmea
-            lastDynamicAt = Date.now()
-
-            // Announce a fresh vessel to aggregators immediately on its
-            // first real dynamic reading; subsequent static reports fall
-            // to the interval below.
-            if (!firstDynamicSeen) {
-              firstDynamicSeen = true
-              sendStaticReport()
-            }
-
-            if (lastPositionTimeout) {
-              clearInterval(lastPositionTimeout)
-              lastPositionTimeout = undefined
-            }
-            if (cfg.lastpositionupdate) {
-              lastPositionTimeout = setInterval(
-                sendLastPositionReport,
-                (cfg.lastpositionupdaterate || 180) * 1000
-              )
-            }
-          })
-
-        const sendLastPositionReport = function () {
-          lastMessages[0] =
-            'last known ' + new Date().toISOString() + ':' + lastMsgNmea
-          cfg.endpoints.forEach((endpoint: Endpoint) => {
-            sendReportMsg(lastMsgNmea, endpoint.ipaddress, endpoint.port)
-          })
         }
-
-        const sendStaticReport = function () {
-          if (
-            lastDynamicAt === undefined ||
-            Date.now() - lastDynamicAt > STATIC_MAX_STALE_MS
-          ) {
-            return
-          }
-          const info = getStaticInfo()
-          if (Object.keys(info).length) {
-            sendStaticPartZero(info, mmsi, cfg.endpoints)
-            sendStaticPartOne(info, mmsi, cfg.endpoints)
-          }
-        }
-
-        timeout = setInterval(
-          sendStaticReport,
-          (cfg.staticupdaterate || 360) * 1000
-        )
-      } catch (e) {
-        plugin.started = false
-        console.error(e)
       }
+      dynamicTimer = setInterval(tick, updateRateSec * 1000)
+
+      const sendLastPositionReport = function () {
+        lastMessages[0] =
+          'last known ' + new Date().toISOString() + ':' + lastMsgNmea
+        cfg.endpoints.forEach((endpoint: Endpoint) => {
+          sendReportMsg(lastMsgNmea, endpoint.ipaddress, endpoint.port)
+        })
+      }
+
+      const sendStaticReport = function () {
+        if (
+          lastDynamicAt === undefined ||
+          Date.now() - lastDynamicAt > STATIC_MAX_STALE_MS
+        ) {
+          return
+        }
+        const info = getStaticInfo()
+        if (Object.keys(info).length) {
+          sendStaticPartZero(info, mmsi, cfg.endpoints)
+          sendStaticPartOne(info, mmsi, cfg.endpoints)
+        }
+      }
+
+      staticTimer = setInterval(sendStaticReport, staticRateSec * 1000)
     },
 
     stop: function () {
-      if (unsubscribe) {
-        unsubscribe()
+      if (dynamicTimer) {
+        clearInterval(dynamicTimer)
+        dynamicTimer = undefined
       }
-      if (timeout) {
-        clearInterval(timeout)
-        timeout = undefined
+      if (staticTimer) {
+        clearInterval(staticTimer)
+        staticTimer = undefined
       }
-      if (lastPositionTimeout) {
-        clearInterval(lastPositionTimeout)
-        lastPositionTimeout = undefined
+      if (lastPositionTimer) {
+        clearInterval(lastPositionTimer)
+        lastPositionTimer = undefined
       }
       // Without closing the UDP socket, the event loop stays alive after
       // the plugin stops. Matters for tests (mocha won't exit) and for any
       // host that may stop + restart the plugin many times.
       if (udpSocket) {
         udpSocket.close()
+        udpSocket = undefined
       }
       // Reset per-run state so a subsequent start() on the same factory
       // instance starts from a clean slate.
@@ -215,9 +285,11 @@ const createPlugin = function (app: ServerAPI) {
       lastMessages[0] = ''
       lastMessages[1] = ''
       lastMessages[2] = ''
+      lastStartError = undefined
     },
 
     statusMessage: function () {
+      if (lastStartError !== undefined) return lastStartError
       return `Last sent messages: position ${lastMessages[0]} Static part 0: ${lastMessages[1]} Static part 1: ${lastMessages[2]}`
     },
     started: false,
@@ -280,7 +352,11 @@ const createPlugin = function (app: ServerAPI) {
     if (udpSocket) {
       udpSocket.send(msg + '\n', 0, msg.length + 1, port, ip, (err) => {
         if (err) {
-          error('Failed to send position report.' + err)
+          error(
+            `aisreporter: send to ${ip}:${port} failed: ${
+              (err as Error).message
+            }`
+          )
         }
       })
     }
@@ -419,7 +495,7 @@ interface StaticInfo {
 
 function createPositionReportMessage(
   mmsi: string,
-  position: Position | undefined,
+  position: Position,
   sog: number | undefined,
   cog: number | undefined,
   head: number | undefined
@@ -430,8 +506,8 @@ function createPositionReportMessage(
     mmsi: mmsi,
     sog: sog !== undefined ? mpsToKn(sog) : undefined,
     accuracy: 0, // 0 = regular GPS, 1 = DGPS
-    lon: position !== undefined ? position.longitude : undefined,
-    lat: position !== undefined ? position.latitude : undefined,
+    lon: position.longitude,
+    lat: position.latitude,
     cog: cog !== undefined ? radsToDeg(cog) : undefined,
     hdg: head !== undefined ? radsToDeg(head) : undefined
   })

--- a/test/plugin.ts
+++ b/test/plugin.ts
@@ -1,27 +1,26 @@
 /*
  * End-to-end tests for the aisreporter plugin.
  *
- * Each test wires the plugin against a stub Signal K app (Bacon buses +
- * getSelfPath map) and a real UDP socket bound to 127.0.0.1. Position
- * and static reports that the plugin emits are captured from the UDP
- * socket so the whole round-trip — stream combine → debounce → AIS
- * encode → UDP send — is exercised in each assertion.
+ * Each test wires the plugin against a stub Signal K app whose only
+ * surface is `getSelfPath`, plus a real UDP socket bound to 127.0.0.1.
+ * Position and static reports that the plugin emits are captured from
+ * the UDP socket so the whole round-trip — polling tick → AIS encode →
+ * UDP send — is exercised in each assertion.
  *
  * Rates are set to 10 ms in most tests so that `setInterval`-driven
- * behaviour (static rebroadcast, last-known-position resend) fires
- * within a mocha test tick without needing a fake-timers dep.
+ * behaviour (dynamic polling, static rebroadcast, last-known-position
+ * resend) fires within a mocha test tick without needing a fake-timers
+ * dep.
  */
 
 import { expect } from 'chai'
 import * as dgram from 'dgram'
-import * as Bacon from 'baconjs'
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const createPlugin = require('../src/index')
 
 interface Harness {
   app: any
-  buses: Record<string, Bacon.Bus<unknown>>
   selfPathValues: Record<string, unknown>
   savedOptions: Array<Record<string, unknown>>
   received: Buffer[]
@@ -45,17 +44,10 @@ async function createHarness(): Promise<Harness> {
     server.bind(0, '127.0.0.1')
   })
 
-  const buses: Record<string, Bacon.Bus<unknown>> = {}
   const selfPathValues: Record<string, unknown> = { mmsi: '123456789' }
   const savedOptions: Array<Record<string, unknown>> = []
 
   const app = {
-    streambundle: {
-      getSelfStream(key: string) {
-        if (!buses[key]) buses[key] = new Bacon.Bus<unknown>()
-        return buses[key]!
-      }
-    },
     getSelfPath(key: string) {
       return selfPathValues[key]
     },
@@ -72,7 +64,6 @@ async function createHarness(): Promise<Harness> {
 
   return {
     app,
-    buses,
     selfPathValues,
     savedOptions,
     received,
@@ -88,15 +79,12 @@ async function createHarness(): Promise<Harness> {
 // setTimeout promises inline.
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms))
 
-// The plugin wraps each source stream in `.toProperty(undefined)` and
-// pipes the tuple through `debounceImmediate`, which only emits on the
-// LEADING edge of a silence window. A single synchronous batch of four
-// pushes only ever produces one emission — the one after the first
-// push, when the other three values are still `undefined`.
-//
-// Workaround: push sog/cog/head first, let the debounce close, then
-// push position. The leading-edge emission in the second window now
-// carries all four values.
+// Mirrors how signalk-server exposes a vessel path: getSelfPath traverses
+// `<key>.value` to reach the leaf scalar/object that the plugin consumes.
+function setNav(h: Harness, key: string, value: unknown): void {
+  h.selfPathValues[`${key}.value`] = value
+}
+
 async function pushPositionInputs(
   h: Harness,
   {
@@ -109,14 +97,12 @@ async function pushPositionInputs(
     sog: number | undefined
     cog: number | undefined
     head: number | undefined
-  }> = {},
-  debounceWindowMs = 15
+  }> = {}
 ) {
-  h.buses['navigation.speedOverGround']!.push(sog)
-  h.buses['navigation.courseOverGroundTrue']!.push(cog)
-  h.buses['navigation.headingTrue']!.push(head)
-  await wait(debounceWindowMs)
-  h.buses['navigation.position']!.push(position)
+  setNav(h, 'navigation.speedOverGround', sog)
+  setNav(h, 'navigation.courseOverGroundTrue', cog)
+  setNav(h, 'navigation.headingTrue', head)
+  setNav(h, 'navigation.position', position)
 }
 
 describe('aisreporter start/stop lifecycle', () => {
@@ -409,9 +395,9 @@ describe('aisreporter AIS field encoding', () => {
       updaterate: 0.01,
       staticupdaterate: 999
     })
-    // Push position only — leave sog / cog / head at their .toProperty
-    // seed of undefined. Bypasses pushPositionInputs's numeric defaults.
-    h.buses['navigation.position']!.push({ latitude: 10, longitude: 20 })
+    // Push position only — leave sog / cog / head undefined.
+    // Bypasses pushPositionInputs's numeric defaults.
+    setNav(h, 'navigation.position', { latitude: 10, longitude: 20 })
     await wait(30)
     plugin.stop()
     await h.close()
@@ -569,6 +555,75 @@ describe('aisreporter AIS field encoding', () => {
   })
 })
 
+describe('aisreporter — change detection (lat/lon dedup)', () => {
+  // The polling tick fires every updaterate ms but emits only when the
+  // current lat/lon differs from the last emitted pair. These tests pin
+  // each side of the && separately so a future loosening of the guard
+  // (e.g. && to ||, or one side hard-wired) is caught.
+
+  it('emits a second frame when only longitude changes', async () => {
+    const h = await createHarness()
+    const plugin = createPlugin(h.app)
+    plugin.start({
+      endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
+      updaterate: 0.01,
+      staticupdaterate: 999,
+      lastpositionupdate: false
+    })
+    await pushPositionInputs(h, { position: { latitude: 10, longitude: 20 } })
+    await wait(30)
+    await pushPositionInputs(h, { position: { latitude: 10, longitude: 21 } })
+    await wait(30)
+    plugin.stop()
+    await h.close()
+    const positionFrames = h.received
+      .map((b) => b.toString().trim())
+      .filter((p) => p.startsWith('!AIVDM'))
+    expect(positionFrames.length).to.equal(2)
+  })
+
+  it('emits a second frame when only latitude changes', async () => {
+    const h = await createHarness()
+    const plugin = createPlugin(h.app)
+    plugin.start({
+      endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
+      updaterate: 0.01,
+      staticupdaterate: 999,
+      lastpositionupdate: false
+    })
+    await pushPositionInputs(h, { position: { latitude: 10, longitude: 20 } })
+    await wait(30)
+    await pushPositionInputs(h, { position: { latitude: 11, longitude: 20 } })
+    await wait(30)
+    plugin.stop()
+    await h.close()
+    const positionFrames = h.received
+      .map((b) => b.toString().trim())
+      .filter((p) => p.startsWith('!AIVDM'))
+    expect(positionFrames.length).to.equal(2)
+  })
+
+  it('does not emit a second frame when lat and lon are identical', async () => {
+    const h = await createHarness()
+    const plugin = createPlugin(h.app)
+    plugin.start({
+      endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
+      updaterate: 0.01,
+      staticupdaterate: 999,
+      lastpositionupdate: false
+    })
+    await pushPositionInputs(h, { position: { latitude: 10, longitude: 20 } })
+    // Let several polling ticks fire while data stays identical.
+    await wait(80)
+    plugin.stop()
+    await h.close()
+    const positionFrames = h.received
+      .map((b) => b.toString().trim())
+      .filter((p) => p.startsWith('!AIVDM'))
+    expect(positionFrames.length).to.equal(1)
+  })
+})
+
 describe('aisreporter — ignores Null-Island and undefined positions', () => {
   it('drops reports with position (0, 0) entirely', async () => {
     const h = await createHarness()
@@ -612,11 +667,11 @@ describe('aisreporter — ignores Null-Island and undefined positions', () => {
       updaterate: 0.01,
       staticupdaterate: 999
     })
-    h.buses['navigation.speedOverGround']!.push(1)
-    h.buses['navigation.courseOverGroundTrue']!.push(0.5)
-    h.buses['navigation.headingTrue']!.push(0.7)
+    setNav(h, 'navigation.speedOverGround', 1)
+    setNav(h, 'navigation.courseOverGroundTrue', 0.5)
+    setNav(h, 'navigation.headingTrue', 0.7)
     await wait(15)
-    h.buses['navigation.position']!.push(undefined)
+    setNav(h, 'navigation.position', undefined)
     await wait(40)
     plugin.stop()
     await h.close()
@@ -1012,6 +1067,198 @@ describe('aisreporter — default rate fallbacks', () => {
   })
 })
 
+describe('aisreporter — start() failure surfaces through statusMessage', () => {
+  it('statusMessage reports the misconfiguration when mmsi is missing', () => {
+    const plugin = createPlugin({
+      getSelfPath: () => undefined,
+      error: () => undefined,
+      debug: () => undefined
+    })
+    plugin.start({})
+    expect(plugin.statusMessage()).to.include('mmsi missing')
+    expect(plugin.started).to.equal(false)
+  })
+
+  it('statusMessage reports the failure when getSelfPath is unavailable', () => {
+    const plugin = createPlugin({
+      error: () => undefined,
+      debug: () => undefined
+    })
+    plugin.start({})
+    expect(plugin.statusMessage()).to.include('app.getSelfPath')
+    expect(plugin.started).to.equal(false)
+  })
+
+  it('clears the start-error message after a successful restart', async () => {
+    const h = await createHarness()
+    delete h.selfPathValues['mmsi']
+    const plugin = createPlugin(h.app)
+    plugin.start({
+      endpoints: [{ ipaddress: '127.0.0.1', port: h.port }]
+    })
+    expect(plugin.statusMessage()).to.include('mmsi missing')
+
+    h.selfPathValues['mmsi'] = '123456789'
+    plugin.start({
+      endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
+      updaterate: 0.01,
+      staticupdaterate: 999
+    })
+    await pushPositionInputs(h)
+    await wait(30)
+    plugin.stop()
+    await h.close()
+    expect(plugin.statusMessage()).to.not.include('mmsi missing')
+  })
+})
+
+describe('aisreporter — endpoint sanitization', () => {
+  it('drops endpoints whose port is out of the 1..65535 range', async () => {
+    const h = await createHarness()
+    const errors: string[] = []
+    h.app.error = (m: string) => errors.push(m)
+    const plugin = createPlugin(h.app)
+    plugin.start({
+      endpoints: [
+        { ipaddress: '127.0.0.1', port: h.port },
+        { ipaddress: '127.0.0.1', port: 0 },
+        { ipaddress: '127.0.0.1', port: 99999 },
+        { ipaddress: '127.0.0.1', port: -1 }
+      ],
+      updaterate: 0.01,
+      staticupdaterate: 999
+    })
+    await pushPositionInputs(h)
+    await wait(40)
+    plugin.stop()
+    await h.close()
+    // Only the valid endpoint received the AIS frame.
+    expect(h.received.length).to.be.at.least(1)
+    // Three invalid ports each logged once at start time.
+    expect(
+      errors.filter((m) => m.includes('invalid port')).length
+    ).to.be.at.least(3)
+  })
+
+  it('drops endpoints with an invalid ipaddress (wrong type, empty, CR/LF)', async () => {
+    const h = await createHarness()
+    const errors: string[] = []
+    h.app.error = (m: string) => errors.push(m)
+    const plugin = createPlugin(h.app)
+    plugin.start({
+      endpoints: [
+        { ipaddress: 12345, port: 12345 },
+        { ipaddress: '', port: 12345 },
+        { ipaddress: '127.0.0.1\r\n.evil', port: 12345 }
+      ],
+      updaterate: 0.01,
+      staticupdaterate: 999
+    })
+    await pushPositionInputs(h)
+    await wait(40)
+    plugin.stop()
+    await h.close()
+    expect(h.received.length).to.equal(0)
+    expect(
+      errors.filter((m) => m.includes('invalid ipaddress')).length
+    ).to.equal(3)
+  })
+
+  it('drops non-object endpoint entries', async () => {
+    const h = await createHarness()
+    const errors: string[] = []
+    h.app.error = (m: string) => errors.push(m)
+    const plugin = createPlugin(h.app)
+    plugin.start({
+      endpoints: [null, 'oops', 42, { ipaddress: '127.0.0.1', port: h.port }],
+      updaterate: 0.01,
+      staticupdaterate: 999
+    })
+    await pushPositionInputs(h)
+    await wait(40)
+    plugin.stop()
+    await h.close()
+    expect(h.received.length).to.be.at.least(1)
+    expect(errors.filter((m) => m.includes('not an object')).length).to.equal(3)
+  })
+})
+
+describe('aisreporter — rate sanitization', () => {
+  it('falls back to default when updaterate is NaN', async () => {
+    const origSetInterval = global.setInterval
+    const delays: number[] = []
+    global.setInterval = ((fn: () => void, ms: number) => {
+      delays.push(ms)
+      return origSetInterval(fn, ms)
+    }) as typeof global.setInterval
+    try {
+      const h = await createHarness()
+      const plugin = createPlugin(h.app)
+      plugin.start({
+        endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
+        updaterate: NaN,
+        staticupdaterate: 999
+      })
+      plugin.stop()
+      await h.close()
+      // Two intervals armed at start: dynamic (default 60s) and static (999s).
+      expect(delays).to.include(60 * 1000)
+    } finally {
+      global.setInterval = origSetInterval
+    }
+  })
+
+  it('falls back to default when staticupdaterate is negative', async () => {
+    const origSetInterval = global.setInterval
+    const delays: number[] = []
+    global.setInterval = ((fn: () => void, ms: number) => {
+      delays.push(ms)
+      return origSetInterval(fn, ms)
+    }) as typeof global.setInterval
+    try {
+      const h = await createHarness()
+      const plugin = createPlugin(h.app)
+      plugin.start({
+        endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
+        updaterate: 0.01,
+        staticupdaterate: -42
+      })
+      plugin.stop()
+      await h.close()
+      expect(delays).to.include(360 * 1000)
+    } finally {
+      global.setInterval = origSetInterval
+    }
+  })
+
+  it('falls back to default when lastpositionupdaterate is a string', async () => {
+    const origSetInterval = global.setInterval
+    const delays: number[] = []
+    global.setInterval = ((fn: () => void, ms: number) => {
+      delays.push(ms)
+      return origSetInterval(fn, ms)
+    }) as typeof global.setInterval
+    try {
+      const h = await createHarness()
+      const plugin = createPlugin(h.app)
+      plugin.start({
+        endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
+        updaterate: 0.01,
+        staticupdaterate: 999,
+        lastpositionupdate: true,
+        lastpositionupdaterate: '180' as unknown as number
+      })
+      await pushPositionInputs(h)
+      await wait(30)
+      plugin.stop()
+      await h.close()
+      expect(delays).to.include(180 * 1000)
+    } finally {
+      global.setInterval = origSetInterval
+    }
+  })
+})
+
 describe('aisreporter plugin falls through its defensive branches', () => {
   it('uses console.error when app.error is missing and mmsi is absent', () => {
     const origErr = console.error
@@ -1082,29 +1329,27 @@ describe('aisreporter plugin falls through its defensive branches', () => {
     expect(h.received.length).to.equal(0)
   })
 
-  it('start() swallows errors thrown during subscription setup and leaves started=false', async () => {
+  it('logs the destination ip:port when a UDP send fails', async () => {
     const h = await createHarness()
-    const origErr = console.error
-    console.error = () => undefined
-    try {
-      // Replace getSelfStream so combineWith setup throws.
-      h.app.streambundle.getSelfStream = () => {
-        throw new Error('stream setup boom')
-      }
-      const plugin = createPlugin(h.app)
-      expect(() =>
-        plugin.start({
-          endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
-          updaterate: 0.01,
-          staticupdaterate: 999
-        })
-      ).to.not.throw()
-      expect(plugin.started).to.equal(false)
-      plugin.stop()
-    } finally {
-      console.error = origErr
-      await h.close()
-    }
+    const errors: string[] = []
+    h.app.error = (m: string) => errors.push(m)
+    // '999.999.999.999' isn't a valid IPv4 literal so dgram.send falls
+    // back to a DNS lookup, which fails ENOTFOUND on the send callback.
+    // This exercises the error-formatting code path with a deterministic
+    // failure that doesn't depend on real network state.
+    const plugin = createPlugin(h.app)
+    plugin.start({
+      endpoints: [{ ipaddress: '999.999.999.999', port: 12345 }],
+      updaterate: 0.01,
+      staticupdaterate: 999
+    })
+    await pushPositionInputs(h)
+    await wait(150)
+    plugin.stop()
+    await h.close()
+    expect(
+      errors.some((m) => m.includes('send to 999.999.999.999:12345 failed:'))
+    ).to.equal(true)
   })
 
   it('stop() clears the lastMessages status slots so a subsequent start() starts fresh', async () => {

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -33,7 +33,7 @@ describe('aisreporter plugin factory', () => {
       error: (m: string) => errors.push(m)
     })
     plugin.start({})
-    expect(errors[0]).to.include('aisreporter needs app.getSelfPath')
+    expect(errors[0]).to.include('app.getSelfPath')
   })
 
   it('start() without an mmsi is a no-op (does not throw)', () => {


### PR DESCRIPTION
## Summary

- Replace `streambundle.combineWith` + `debounceImmediate` with a `setInterval` polling loop reading vessel state through `app.getSelfPath`. Removes the dual-Bacon prototype-identity failure mode reported in #46 (silent stream stall on signalk-server v2.13.5 on Venus Cerbo GX, where the host's baconjs 1.x and the plugin's transitive baconjs 3.x produce stream pipelines that wire up but never emit). Same fault class previously fixed in signalk-to-nmea0183 v1.14.5; here we go further and drop baconjs entirely since this plugin's semantics are timer-driven, not event-driven.
- Lat/lon-based change detection preserves the `.changes()` semantic and protects stuck-GPS hosts from spamming aggregators every tick.
- Sanitize endpoint config (ipaddress, port) and rate fields at `start()`: malformed entries are skipped with a logged warning instead of trashing dgram or arming a pathologically tight `setInterval`.
- Misconfigured starts (missing mmsi, server too old) now surface through `statusMessage()` and set `plugin.started = false`, so the admin UI no longer shows "running" for an inert plugin.
- UDP send errors include the destination ip:port for diagnosability.
- `baconjs` removed from `peerDependencies` and `devDependencies`; runtime deps narrow to `ggencoder` + node built-ins.

Closes #46.

## Test plan

- [x] `npm test` (57 mocha tests, includes new pinning tests for change-detection, endpoint sanitization, rate sanitization, statusMessage on misconfig)
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] `npm run mutation` (Stryker, 81% — survivors mostly in pre-existing helpers and schema metadata strings)
- [x] End-to-end in Docker against signalk-server **v2.13.5** (issue reporter's exact version, Venus baseline ships baconjs 1.x): type-18 position frames every 2s, type-24 static parts every 5s, MMSI in payload decodes to the configured 230099999.
- [x] End-to-end in Docker against signalk-server **latest**: identical behavior.