### PR TITLE
chore: drop Node 20/22, support Node 24/26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,21 +15,14 @@ concurrency:
 
 jobs:
   test:
-    name: Node ${{ matrix.node-version }} / baconjs ${{ matrix.baconjs }}
+    name: Node ${{ matrix.node-version }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x, 24.x]
-        # Dual baconjs matrix exists because Cerbo GX / Venus OS still
-        # bundles an older signalk-server that pins baconjs 1.x in
-        # `node_modules`, while upstream signalk-server is on baconjs
-        # 3.x. Testing both keeps the plugin usable on Cerbo today.
-        # Drop the `1.0.1` cell once Cerbo ships a signalk-server with
-        # baconjs 3.x.
-        baconjs: ['1.0.1', '3.0.23']
+        node-version: [24.x, 26.x]
 
     steps:
       - name: Checkout
@@ -44,34 +37,28 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Pin baconjs to ${{ matrix.baconjs }}
-        run: npm install --no-save baconjs@${{ matrix.baconjs }}
-
       - name: Check formatting
-        if: matrix.baconjs == '3.0.23'
         run: npm run prettier:check
 
       - name: Typecheck
-        if: matrix.baconjs == '3.0.23'
         run: npm run typecheck
 
       - name: Build
-        if: matrix.baconjs == '3.0.23'
         run: npm run build
 
       - name: Run tests
-        if: matrix.node-version != '24.x' || matrix.baconjs != '3.0.23'
+        if: matrix.node-version != '24.x'
         run: npm test
 
       - name: Run tests with coverage
-        if: matrix.node-version == '24.x' && matrix.baconjs == '3.0.23'
+        if: matrix.node-version == '24.x'
         shell: bash
         run: |
           set -eo pipefail
           npm run coverage | tee coverage.log
 
       - name: Coverage step summary
-        if: matrix.node-version == '24.x' && matrix.baconjs == '3.0.23'
+        if: matrix.node-version == '24.x'
         shell: bash
         run: |
           {
@@ -83,7 +70,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload coverage (lcov) as artifact
-        if: matrix.node-version == '24.x' && matrix.baconjs == '3.0.23'
+        if: matrix.node-version == '24.x'
         uses: actions/upload-artifact@v7
         with:
           name: coverage-lcov

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,7 @@
         "typescript": "^6.0.3"
       },
       "engines": {
-        "//": "Floor at 20.10 to support Venus CerboGX firmware (currently Node 20.18.2). Bump back to >=22 once Cerbo ships a newer Node.",
-        "node": ">=20.10"
+        "node": ">=24"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     ]
   },
   "engines": {
-    "//": "Floor at 20.10 to support Venus CerboGX firmware (currently Node 20.18.2). Bump back to >=22 once Cerbo ships a newer Node.",
-    "node": ">=20.10"
+    "node": ">=24"
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",


### PR DESCRIPTION
> **Hold for Venus OS.** This is going to land as soon as Venus OS supports Node v24 (see [Discord context](https://discord.com/channels/1170433917761892493/1512189657666949441/1512439811477078048)).

Drop Node 20 and 22, support Node 24 and 26.

- `engines.node`: `>=20.10` → `>=24` (drops the Cerbo special-case; the Cerbo runtime will catch up, and `>=24` unlocks Node 24+ APIs).
- CI matrix: `[20.x, 22.x, 24.x]` → `[24.x, 26.x]`. Coverage stays on Node 24 (LTS); 26.x is the regression-catcher.
- `@types/node`: bumped to `^25.9.2` (latest published; DefinitelyTyped hasn't released `@types/node@26` yet — Node 26 only landed a few days ago. Bump again once DT publishes).
- baconjs matrix dimension dropped (the `1.0.1` cell only existed for Cerbo's old signalk-server). Default install pulls `baconjs ^3.0.0` and CI runs against that single version.