### PR TITLE
fix: send proper AIS not-available values for missing heading, SOG, and COG

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,14 +36,35 @@ function isNullIsland(position: Position): boolean {
 // pinging aggregators with ghost static data.
 const STATIC_MAX_STALE_MS = 10 * 60 * 1000
 
-// AIS true-heading field (type 18/1/2/3): 9-bit integer degrees with 511
-// reserved for "heading not available". We must send 511 explicitly when
-// we have no heading. ggencoder otherwise substitutes COG for a missing
-// heading, which paints the vessel pointing along its course even when
-// the real heading differs (current set, leeway, sternway) — up to 180
-// degrees wrong. A Class B target with no heading sensor is expected to
-// report 511, not a faked course.
+// AIS "not available" sentinels for a type-18 report's dynamic fields.
+// When Signal K lacks a value the plugin must send the spec sentinel, not
+// leave it undefined: ggencoder then fills the field with a real-looking
+// zero (SOG 0 kn = "stopped", COG/heading 0° = "due north"), which lies to
+// aggregators. The values below are the decoded forms; ggencoder scales
+// them to the on-the-wire sentinels (SOG raw 1023, COG raw 3600).
+
+// SOG field: 10-bit, 0.1 kn units. Signal K speed is m/s; 102.3 kn → 1023.
+const AIS_SOG_NOT_AVAILABLE_KN = 102.3
+
+// COG field: 12-bit, 0.1 deg units. 360 deg → raw 3600.
+const AIS_COG_NOT_AVAILABLE_DEG = 360
+
+// True-heading field: 9-bit integer degrees with 511 reserved for "not
+// available". We must send 511 explicitly when we have no heading.
+// ggencoder otherwise substitutes COG for a missing heading, which paints
+// the vessel pointing along its course even when the real heading differs
+// (current set, leeway, sternway) — up to 180 degrees wrong. A Class B
+// target with no heading sensor is expected to report 511, not a faked
+// course.
 const AIS_HEADING_NOT_AVAILABLE = 511
+
+// Encoder workaround, NOT an AIS field value. ggencoder encodes heading via
+// `parseInt(hdg) || parseInt(cog)` and writes only the low 9 bits of the
+// field, so a 0-degree (due north) heading is falsy and gets replaced with
+// COG. The carry bit just above the 9-bit field (1 << 9 = 512) stays truthy
+// through that guard yet masks to a clean 0 on the wire, letting us send a
+// real due-north heading rather than lose it to COG.
+const AIS_HEADING_DUE_NORTH_CARRY = 1 << 9 // 512
 
 // Earlier schema versions persisted these typo'd keys, so existing
 // users have them baked into their `plugin-config-data/aisreporter.json`.
@@ -511,13 +532,29 @@ function createPositionReportMessage(
     aistype: 18, // class B position report
     repeat: 0,
     mmsi: mmsi,
-    sog: sog !== undefined ? mpsToKn(sog) : undefined,
+    sog: sogToAisField(sog),
     accuracy: 0, // 0 = regular GPS, 1 = DGPS
     lon: position.longitude,
     lat: position.latitude,
-    cog: cog !== undefined ? radsToDeg(cog) : undefined,
+    cog: cogToAisField(cog),
     hdg: headingToAisField(head)
   })
+}
+
+// Map Signal K speed (m/s) to the AIS SOG field in knots, or the
+// not-available sentinel when speed is unknown.
+function sogToAisField(sogMps: number | undefined): number {
+  if (sogMps === undefined) return AIS_SOG_NOT_AVAILABLE_KN
+  return mpsToKn(sogMps)
+}
+
+// Map a course over ground (radians) to the AIS COG field in degrees, or
+// the not-available sentinel when course is unknown.
+function cogToAisField(cogRad: number | undefined): number {
+  if (cogRad === undefined) return AIS_COG_NOT_AVAILABLE_DEG
+  // Normalize into [0, 360) so a course at/over one full turn can't collide
+  // with the 3600 "not available" sentinel.
+  return ((radsToDeg(cogRad) % 360) + 360) % 360
 }
 
 // Resolve a true heading (radians) for the AIS report:
@@ -555,16 +592,15 @@ function resolveTrueHeadingRad(app: ServerAPI): number | undefined {
 // Map a true heading (radians) to the AIS heading field: integer degrees
 // in [0, 360), or the 511 "not available" sentinel when no heading is
 // known. ggencoder truncates the value to an integer degree.
-//
-// Known limitation: a heading that truncates to exactly 0 (due north) is
-// re-substituted with COG inside ggencoder, whose `parseInt(hdg) ||
-// parseInt(cog)` treats 0 as falsy. That is a one-degree window we cannot
-// close without an upstream fix; everything else encodes faithfully.
 function headingToAisField(headingRad: number | undefined): number {
   if (headingRad === undefined) return AIS_HEADING_NOT_AVAILABLE
   // A derived magnetic + variation sum can fall outside one turn; normalize
   // (including negatives) back into [0, 360).
-  return ((radsToDeg(headingRad) % 360) + 360) % 360
+  const deg = ((radsToDeg(headingRad) % 360) + 360) % 360
+  // Route a due-north heading through the carry-bit form; see the constant
+  // for why ggencoder needs it.
+  if (Math.trunc(deg) === 0) return AIS_HEADING_DUE_NORTH_CARRY
+  return deg
 }
 
 function radsToDeg(radians: number): number {

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,15 @@ function isNullIsland(position: Position): boolean {
 // pinging aggregators with ghost static data.
 const STATIC_MAX_STALE_MS = 10 * 60 * 1000
 
+// AIS true-heading field (type 18/1/2/3): 9-bit integer degrees with 511
+// reserved for "heading not available". We must send 511 explicitly when
+// we have no heading. ggencoder otherwise substitutes COG for a missing
+// heading, which paints the vessel pointing along its course even when
+// the real heading differs (current set, leeway, sternway) — up to 180
+// degrees wrong. A Class B target with no heading sensor is expected to
+// report 511, not a faked course.
+const AIS_HEADING_NOT_AVAILABLE = 511
+
 // Earlier schema versions persisted these typo'd keys, so existing
 // users have them baked into their `plugin-config-data/aisreporter.json`.
 // We publish the corrected keys, read either spelling (new wins), and —
@@ -188,9 +197,7 @@ const createPlugin = function (app: ServerAPI) {
         const cog = app.getSelfPath('navigation.courseOverGroundTrue.value') as
           | number
           | undefined
-        const head = app.getSelfPath('navigation.headingTrue.value') as
-          | number
-          | undefined
+        const head = resolveTrueHeadingRad(app)
 
         const nmea = createPositionReportMessage(
           mmsi,
@@ -509,8 +516,55 @@ function createPositionReportMessage(
     lon: position.longitude,
     lat: position.latitude,
     cog: cog !== undefined ? radsToDeg(cog) : undefined,
-    hdg: head !== undefined ? radsToDeg(head) : undefined
+    hdg: headingToAisField(head)
   })
+}
+
+// Resolve a true heading (radians) for the AIS report:
+//   1. navigation.headingTrue when present;
+//   2. else derive true from navigation.headingMagnetic + magneticVariation
+//      (a compass emitting NMEA HDG rather than HDT leaves Signal K with
+//      only a magnetic heading, so without this the plugin would report no
+//      heading at all);
+//   3. else undefined, signalling "no heading known".
+function resolveTrueHeadingRad(app: ServerAPI): number | undefined {
+  const headingTrue = app.getSelfPath('navigation.headingTrue.value') as
+    | number
+    | undefined
+  if (typeof headingTrue === 'number' && Number.isFinite(headingTrue)) {
+    return headingTrue
+  }
+  const headingMagnetic = app.getSelfPath(
+    'navigation.headingMagnetic.value'
+  ) as number | undefined
+  const variation = app.getSelfPath('navigation.magneticVariation.value') as
+    | number
+    | undefined
+  if (
+    typeof headingMagnetic === 'number' &&
+    Number.isFinite(headingMagnetic) &&
+    typeof variation === 'number' &&
+    Number.isFinite(variation)
+  ) {
+    // Signal K stores variation east-positive, so true = magnetic + variation.
+    return headingMagnetic + variation
+  }
+  return undefined
+}
+
+// Map a true heading (radians) to the AIS heading field: integer degrees
+// in [0, 360), or the 511 "not available" sentinel when no heading is
+// known. ggencoder truncates the value to an integer degree.
+//
+// Known limitation: a heading that truncates to exactly 0 (due north) is
+// re-substituted with COG inside ggencoder, whose `parseInt(hdg) ||
+// parseInt(cog)` treats 0 as falsy. That is a one-degree window we cannot
+// close without an upstream fix; everything else encodes faithfully.
+function headingToAisField(headingRad: number | undefined): number {
+  if (headingRad === undefined) return AIS_HEADING_NOT_AVAILABLE
+  // A derived magnetic + variation sum can fall outside one turn; normalize
+  // (including negatives) back into [0, 360).
+  return ((radsToDeg(headingRad) % 360) + 360) % 360
 }
 
 function radsToDeg(radians: number): number {

--- a/test/plugin.ts
+++ b/test/plugin.ts
@@ -386,7 +386,7 @@ describe('aisreporter AIS field encoding', () => {
     ).to.include(expected)
   })
 
-  it('still encodes position with sog / cog / hdg unset, sending hdg = 511 (not available)', async () => {
+  it('encodes position with sog / cog / hdg unset using the AIS not-available sentinels', async () => {
     const h = await createHarness()
     h.selfPathValues['mmsi'] = MMSI
     const plugin = createPlugin(h.app)
@@ -406,13 +406,13 @@ describe('aisreporter AIS field encoding', () => {
       aistype: 18,
       repeat: 0,
       mmsi: MMSI,
-      sog: undefined,
+      // Missing dynamics must carry the AIS "not available" sentinels, not
+      // faked zeros: SOG 102.3 kn → 1023, COG 360° → 3600, heading 511.
+      sog: 102.3,
       accuracy: 0,
       lon: 20,
       lat: 10,
-      cog: undefined,
-      // With no heading source the field must carry the AIS "not available"
-      // sentinel, not a faked heading.
+      cog: 360,
       hdg: 511
     }).nmea
 
@@ -694,16 +694,95 @@ describe('aisreporter heading resolution', () => {
     expect(decoded.hdg).to.equal(511)
   })
 
-  it('characterizes the ggencoder due-north limitation: a 0° heading falls back to COG', async () => {
-    // Documented gap in headingToAisField: ggencoder's
-    // `parseInt(hdg) || parseInt(cog)` treats a 0° heading as falsy and
-    // substitutes COG. This pins the current behavior so a future upstream
-    // fix surfaces as a visible test diff rather than a silent change.
+  it('encodes a due-north (0°) heading as 0, not COG', async () => {
+    // ggencoder's `parseInt(hdg) || parseInt(cog)` would drop a 0° heading
+    // and substitute COG (28 here). headingToAisField sends the carry-bit
+    // form (512) so the wire heading is a faithful 0.
     const decoded = new AisDecode(
       await emitFrame({ ...baseNav, 'navigation.headingTrue': 0 })
     )
-    const cogDeg = Math.trunc((0.5 * 180) / Math.PI) // 28
-    expect(decoded.hdg).to.equal(cogDeg)
+    expect(decoded.hdg).to.equal(0)
+  })
+
+  it('encodes a sub-1° heading (truncates toward north) as 0, not COG', async () => {
+    // 0.4° → ~0.00698 rad. ggencoder would parseInt-truncate to 0 and fall
+    // back to COG; the carry-bit form keeps it a faithful 0.
+    const decoded = new AisDecode(
+      await emitFrame({
+        ...baseNav,
+        'navigation.headingTrue': (0.4 * Math.PI) / 180
+      })
+    )
+    expect(decoded.hdg).to.equal(0)
+  })
+})
+
+describe('aisreporter not-available dynamics (SOG / COG)', () => {
+  // Missing speed / course must encode as the AIS "not available" sentinels,
+  // never a real-looking 0 that tells aggregators the vessel is stopped and
+  // heading due north.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { AisDecode } = require('ggencoder')
+  const MMSI = '123456789'
+
+  async function emitFrame(nav: Record<string, unknown>): Promise<string> {
+    const h = await createHarness()
+    h.selfPathValues['mmsi'] = MMSI
+    const plugin = createPlugin(h.app)
+    plugin.start({
+      endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
+      updaterate: 0.01,
+      staticupdaterate: 999
+    })
+    for (const [key, value] of Object.entries(nav)) setNav(h, key, value)
+    await wait(30)
+    plugin.stop()
+    await h.close()
+    return (
+      h.received
+        .map((b) => b.toString().trim())
+        .find((p) => p.startsWith('!AIVDM')) ?? ''
+    )
+  }
+
+  // Position + heading present so only SOG / COG are exercised per test.
+  const position = { latitude: 10, longitude: 20 }
+
+  it('sends SOG = 102.3 (not available) when speed is missing, not 0', async () => {
+    const decoded = new AisDecode(
+      await emitFrame({
+        'navigation.position': position,
+        'navigation.courseOverGroundTrue': 0.5,
+        'navigation.headingTrue': 0.7
+      })
+    )
+    expect(decoded.sog).to.equal(102.3)
+  })
+
+  it('sends COG = 360 (not available) when course is missing, not 0', async () => {
+    const decoded = new AisDecode(
+      await emitFrame({
+        'navigation.position': position,
+        'navigation.speedOverGround': 5,
+        'navigation.headingTrue': 0.7
+      })
+    )
+    expect(decoded.cog).to.equal(360)
+  })
+
+  it('encodes real SOG / COG normally when present (not the sentinels)', async () => {
+    // 5 m/s → 9.7 kn; 0.5 rad → 28.6°. Guards against the helpers ever
+    // returning the not-available value for real data.
+    const decoded = new AisDecode(
+      await emitFrame({
+        'navigation.position': position,
+        'navigation.speedOverGround': 5,
+        'navigation.courseOverGroundTrue': 0.5,
+        'navigation.headingTrue': 0.7
+      })
+    )
+    expect(decoded.sog).to.equal(9.7)
+    expect(decoded.cog).to.equal(28.6)
   })
 })
 

--- a/test/plugin.ts
+++ b/test/plugin.ts
@@ -386,7 +386,7 @@ describe('aisreporter AIS field encoding', () => {
     ).to.include(expected)
   })
 
-  it('still encodes position with sog / cog / hdg unset (only position is required)', async () => {
+  it('still encodes position with sog / cog / hdg unset, sending hdg = 511 (not available)', async () => {
     const h = await createHarness()
     h.selfPathValues['mmsi'] = MMSI
     const plugin = createPlugin(h.app)
@@ -411,7 +411,9 @@ describe('aisreporter AIS field encoding', () => {
       lon: 20,
       lat: 10,
       cog: undefined,
-      hdg: undefined
+      // With no heading source the field must carry the AIS "not available"
+      // sentinel, not a faked heading.
+      hdg: 511
     }).nmea
 
     const actual = h.received.map((b) => b.toString().trim())
@@ -552,6 +554,156 @@ describe('aisreporter AIS field encoding', () => {
       dimD: '3'
     }).nmea
     expect(h.received.map((b) => b.toString().trim())).to.include(expected)
+  })
+})
+
+describe('aisreporter heading resolution', () => {
+  // Regression cover for the "vessel outline 180 degrees wrong" report:
+  // when Signal K has no navigation.headingTrue, the plugin must not let
+  // a heading equal to COG be emitted. It should derive a true heading
+  // from magnetic + variation, or send the 511 "not available" sentinel.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { AisEncode, AisDecode } = require('ggencoder')
+  const MMSI = '123456789'
+
+  // Drive one polling tick with the given self-path values and return the
+  // first emitted class-B position frame.
+  async function emitFrame(nav: Record<string, unknown>): Promise<string> {
+    const h = await createHarness()
+    h.selfPathValues['mmsi'] = MMSI
+    const plugin = createPlugin(h.app)
+    plugin.start({
+      endpoints: [{ ipaddress: '127.0.0.1', port: h.port }],
+      updaterate: 0.01,
+      staticupdaterate: 999
+    })
+    for (const [key, value] of Object.entries(nav)) setNav(h, key, value)
+    await wait(30)
+    plugin.stop()
+    await h.close()
+    return (
+      h.received
+        .map((b) => b.toString().trim())
+        .find((p) => p.startsWith('!AIVDM')) ?? ''
+    )
+  }
+
+  const baseNav = {
+    'navigation.position': { latitude: 10, longitude: 20 },
+    'navigation.speedOverGround': 5,
+    'navigation.courseOverGroundTrue': 0.5
+  }
+
+  it('sends hdg = 511 (not COG) when no heading source exists', async () => {
+    // Under the original bug a missing heading encoded as COG (28 here),
+    // so asserting the not-available sentinel pins the regression directly.
+    const decoded = new AisDecode(await emitFrame({ ...baseNav }))
+    expect(decoded.hdg).to.equal(511)
+  })
+
+  it('uses navigation.headingTrue when present, ignoring magnetic + variation', async () => {
+    const nmea = await emitFrame({
+      ...baseNav,
+      'navigation.headingTrue': 2.0,
+      'navigation.headingMagnetic': 1.0,
+      'navigation.magneticVariation': 0.1
+    })
+    const expected: string = new AisEncode({
+      aistype: 18,
+      repeat: 0,
+      mmsi: MMSI,
+      sog: 5 * 1.9438444924574,
+      accuracy: 0,
+      lon: 20,
+      lat: 10,
+      cog: (0.5 * 180) / Math.PI,
+      hdg: (2.0 * 180) / Math.PI
+    }).nmea
+    expect(nmea).to.equal(expected)
+  })
+
+  it('derives true heading from magnetic + east variation when headingTrue is absent', async () => {
+    const nmea = await emitFrame({
+      ...baseNav,
+      'navigation.headingMagnetic': 2.0,
+      'navigation.magneticVariation': 0.3
+    })
+    const expected: string = new AisEncode({
+      aistype: 18,
+      repeat: 0,
+      mmsi: MMSI,
+      sog: 5 * 1.9438444924574,
+      accuracy: 0,
+      lon: 20,
+      lat: 10,
+      cog: (0.5 * 180) / Math.PI,
+      // true = magnetic + variation (east positive)
+      hdg: ((2.0 + 0.3) * 180) / Math.PI
+    }).nmea
+    expect(nmea).to.equal(expected)
+  })
+
+  it('subtracts west (negative) variation when deriving true heading', async () => {
+    const nmea = await emitFrame({
+      ...baseNav,
+      'navigation.headingMagnetic': 2.0,
+      'navigation.magneticVariation': -0.3
+    })
+    const expected: string = new AisEncode({
+      aistype: 18,
+      repeat: 0,
+      mmsi: MMSI,
+      sog: 5 * 1.9438444924574,
+      accuracy: 0,
+      lon: 20,
+      lat: 10,
+      cog: (0.5 * 180) / Math.PI,
+      hdg: ((2.0 - 0.3) * 180) / Math.PI
+    }).nmea
+    expect(nmea).to.equal(expected)
+  })
+
+  it('normalizes a derived heading that exceeds one full turn into [0, 360)', async () => {
+    // 6.0 rad (≈344°) + 0.5 rad (≈29°) wraps past 360° to ≈12°.
+    const nmea = await emitFrame({
+      ...baseNav,
+      'navigation.headingMagnetic': 6.0,
+      'navigation.magneticVariation': 0.5
+    })
+    const expected: string = new AisEncode({
+      aistype: 18,
+      repeat: 0,
+      mmsi: MMSI,
+      sog: 5 * 1.9438444924574,
+      accuracy: 0,
+      lon: 20,
+      lat: 10,
+      cog: (0.5 * 180) / Math.PI,
+      hdg: (((((6.0 + 0.5) * 180) / Math.PI) % 360) + 360) % 360
+    }).nmea
+    expect(nmea).to.equal(expected)
+  })
+
+  it('sends hdg = 511 when only magnetic heading is known (no variation to true)', async () => {
+    const decoded = new AisDecode(
+      await emitFrame({
+        ...baseNav,
+        'navigation.headingMagnetic': 2.0
+      })
+    )
+    expect(decoded.hdg).to.equal(511)
+  })
+
+  it('characterizes the ggencoder due-north limitation: a 0° heading falls back to COG', async () => {
+    // Documented gap in headingToAisField: ggencoder's
+    // `parseInt(hdg) || parseInt(cog)` treats a 0° heading as falsy and
+    // substitutes COG. This pins the current behavior so a future upstream
+    // fix surfaces as a visible test diff rather than a silent change.
+    const decoded = new AisDecode(
+      await emitFrame({ ...baseNav, 'navigation.headingTrue': 0 })
+    )
+    const cogDeg = Math.trunc((0.5 * 180) / Math.PI) // 28
+    expect(decoded.hdg).to.equal(cogDeg)
   })
 })
 


### PR DESCRIPTION
## Summary

Fixes #63 (reported vessel heading 180° wrong on MarineTraffic) and the related class of bug it exposed: when a dynamic field is missing, the plugin let `ggencoder` encode a real-looking `0` instead of the AIS "not available" sentinel, sending fabricated data to aggregators.

### Heading (the reported bug)

When Signal K has no `navigation.headingTrue`, the plugin passed an undefined heading. ggencoder's `hdg = parseInt(msg.hdg) || parseInt(msg.cog)` then substitutes course over ground, so the vessel outline is drawn pointing along its track even when the real heading differs (current set, leeway, sternway) — up to 180° wrong. This matched the reporter's data: heading shown as ~140 (their COG) instead of their true 183.

- Resolve true heading from `navigation.headingTrue`, else derive from `navigation.headingMagnetic` + `navigation.magneticVariation` (east-positive). This covers a compass that emits NMEA HDG rather than HDT.
- When no heading is known, send the `511` "not available" sentinel explicitly so ggencoder cannot fall back to COG.
- Encode a genuine **due-north (0°)** heading correctly. ggencoder treats `0` as falsy and would swap it for COG; passing the carry bit just above the 9-bit field (`1 << 9 = 512`) stays truthy through the guard yet masks to a faithful `0` on the wire. Verified by decode round-trip with all adjacent fields intact.

### SOG / COG (same root cause)

A missing speed encoded as `0 kn` ("stopped") and a missing course as `0°` ("due north"). Both now send the AIS not-available sentinels: SOG `102.3` → raw 1023, COG `360` → raw 3600.

## Scope checked

Swept every type-18 and type-24 field for the same `undefined → 0` pattern. Only `sog`, `cog`, and `hdg` were reachable bugs; position, accuracy, and all static (type-24) fields already supply valid values or correct defaults. The AIS sentinel values were cross-checked against ITU-R M.1371 independently of the code.

## Tests

Added `heading resolution` and `not-available dynamics` suites: no-heading → 511, headingTrue precedence, magnetic+variation derivation (east/west), >360° normalization, magnetic-without-variation → 511, due-north and sub-1° → wire 0, and SOG/COG missing → sentinels (with a guard that real values still encode normally). All decode the emitted frame and assert the wire value. Full suite (68 tests), typecheck, and prettier pass.