### PR TITLE
chore: drop ggencoder due-north heading workaround (bump to 1.0.10)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.3.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "ggencoder": "^1.0.9"
+        "ggencoder": "^1.0.10"
       },
       "devDependencies": {
         "@signalk/server-api": "^2.24.0",
@@ -2544,9 +2544,9 @@
       }
     },
     "node_modules/ggencoder": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/ggencoder/-/ggencoder-1.0.9.tgz",
-      "integrity": "sha512-k8a5axQFN10t+AC+E/YPZ/JXXpmAb9RIcO6uUrVniPfiQCBNtRDLIqQU4DzYXzYbicK0Tmr5pa8PHCrn+oUlkA==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/ggencoder/-/ggencoder-1.0.10.tgz",
+      "integrity": "sha512-BSPJ4UREILM098WorrrRUs4wYRGQYEJzS7gUkK6WAKYKP1zZ92NdhFIrqW3JuVp1ZwGVmXezA6ExEdFnnAW8KQ==",
       "license": "apache20",
       "bin": {
         "Ais2JsonClient": "bin/Ais2JsonClient.js"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     ]
   },
   "dependencies": {
-    "ggencoder": "^1.0.9"
+    "ggencoder": "^1.0.10"
   },
   "devDependencies": {
     "@signalk/server-api": "^2.24.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,12 +36,12 @@ function isNullIsland(position: Position): boolean {
 // pinging aggregators with ghost static data.
 const STATIC_MAX_STALE_MS = 10 * 60 * 1000
 
-// AIS "not available" sentinels for a type-18 report's dynamic fields.
-// When Signal K lacks a value the plugin must send the spec sentinel, not
-// leave it undefined: ggencoder then fills the field with a real-looking
-// zero (SOG 0 kn = "stopped", COG/heading 0° = "due north"), which lies to
-// aggregators. The values below are the decoded forms; ggencoder scales
-// them to the on-the-wire sentinels (SOG raw 1023, COG raw 3600).
+// AIS "not available" sentinels for a type-18 report's SOG and COG fields.
+// When Signal K lacks a value the plugin must send the spec sentinel:
+// ggencoder otherwise leaves the field at zero (SOG 0 kn = "stopped",
+// COG 0° = "due north"), which lies to aggregators. The values below are
+// the decoded forms; ggencoder scales them to the on-the-wire sentinels
+// (SOG raw 1023, COG raw 3600).
 
 // SOG field: 10-bit, 0.1 kn units. Signal K speed is m/s; 102.3 kn → 1023.
 const AIS_SOG_NOT_AVAILABLE_KN = 102.3
@@ -50,21 +50,11 @@ const AIS_SOG_NOT_AVAILABLE_KN = 102.3
 const AIS_COG_NOT_AVAILABLE_DEG = 360
 
 // True-heading field: 9-bit integer degrees with 511 reserved for "not
-// available". We must send 511 explicitly when we have no heading.
-// ggencoder otherwise substitutes COG for a missing heading, which paints
-// the vessel pointing along its course even when the real heading differs
-// (current set, leeway, sternway) — up to 180 degrees wrong. A Class B
-// target with no heading sensor is expected to report 511, not a faked
-// course.
+// available". A Class B target with no heading sensor is expected to report
+// 511; we send it explicitly when Signal K has no true heading so
+// aggregators orient the vessel by a real heading or not at all, never by a
+// fabricated course.
 const AIS_HEADING_NOT_AVAILABLE = 511
-
-// Encoder workaround, NOT an AIS field value. ggencoder encodes heading via
-// `parseInt(hdg) || parseInt(cog)` and writes only the low 9 bits of the
-// field, so a 0-degree (due north) heading is falsy and gets replaced with
-// COG. The carry bit just above the 9-bit field (1 << 9 = 512) stays truthy
-// through that guard yet masks to a clean 0 on the wire, letting us send a
-// real due-north heading rather than lose it to COG.
-const AIS_HEADING_DUE_NORTH_CARRY = 1 << 9 // 512
 
 // Earlier schema versions persisted these typo'd keys, so existing
 // users have them baked into their `plugin-config-data/aisreporter.json`.
@@ -596,11 +586,7 @@ function headingToAisField(headingRad: number | undefined): number {
   if (headingRad === undefined) return AIS_HEADING_NOT_AVAILABLE
   // A derived magnetic + variation sum can fall outside one turn; normalize
   // (including negatives) back into [0, 360).
-  const deg = ((radsToDeg(headingRad) % 360) + 360) % 360
-  // Route a due-north heading through the carry-bit form; see the constant
-  // for why ggencoder needs it.
-  if (Math.trunc(deg) === 0) return AIS_HEADING_DUE_NORTH_CARRY
-  return deg
+  return ((radsToDeg(headingRad) % 360) + 360) % 360
 }
 
 function radsToDeg(radians: number): number {

--- a/test/plugin.ts
+++ b/test/plugin.ts
@@ -695,9 +695,8 @@ describe('aisreporter heading resolution', () => {
   })
 
   it('encodes a due-north (0°) heading as 0, not COG', async () => {
-    // ggencoder's `parseInt(hdg) || parseInt(cog)` would drop a 0° heading
-    // and substitute COG (28 here). headingToAisField sends the carry-bit
-    // form (512) so the wire heading is a faithful 0.
+    // A 0° heading must encode as a faithful 0 (north), never fall through
+    // to COG (28 here).
     const decoded = new AisDecode(
       await emitFrame({ ...baseNav, 'navigation.headingTrue': 0 })
     )
@@ -705,8 +704,7 @@ describe('aisreporter heading resolution', () => {
   })
 
   it('encodes a sub-1° heading (truncates toward north) as 0, not COG', async () => {
-    // 0.4° → ~0.00698 rad. ggencoder would parseInt-truncate to 0 and fall
-    // back to COG; the carry-bit form keeps it a faithful 0.
+    // 0.4° → ~0.00698 rad, truncates to 0; must still be a faithful 0.
     const decoded = new AisDecode(
       await emitFrame({
         ...baseNav,


### PR DESCRIPTION
Closes #67.

ggencoder 1.0.10 fixes the encoder bug behind the due-north workaround (fulup-bzh/GeoGate@7df5311, see fulup-bzh/GeoGate#63): a 0° true heading is now encoded as `0` instead of being dropped in favour of COG.

## Changes

- Bump `ggencoder` to `^1.0.10`. The floor moves with the removal because on 1.0.9 a north heading would regress.
- Remove the `AIS_HEADING_DUE_NORTH_CARRY` (`1 << 9`) constant and the `Math.trunc(deg) === 0` branch in `headingToAisField`; a 0° heading now encodes natively.
- Refresh comments that referenced the old ggencoder behavior.

## Kept

- `resolveTrueHeadingRad` (magnetic + variation derivation) and the explicit `511` for a missing heading.
- The `sogToAisField` / `cogToAisField` not-available sentinels — ggencoder 1.0.10 did **not** touch SOG/COG, which still encode a misleading `0` without them.

## Verification

No behavior change in the plugin's output: a 0° heading already encoded as `0` via the carry-bit trick, and still does natively. The two due-north tests pass unchanged against 1.0.10. Full suite (68), typecheck, and prettier pass. Bonus from the bump: the type-18 decoder timestamp fix and `Buffer.alloc` deprecation fix (neither used directly by this plugin).